### PR TITLE
GH-633 (adolescent): Optimise routing to reduce DNS resolution 'mark'

### DIFF
--- a/multinode_integration_tests/src/neighborhood_constructor.rs
+++ b/multinode_integration_tests/src/neighborhood_constructor.rs
@@ -250,6 +250,7 @@ fn from_masq_node_to_node_record(masq_node: &dyn MASQNode) -> NodeRecord {
             desirable_for_exit: true,
             last_update: time_t_timestamp(),
             node_addr_opt: agr.node_addr_opt.clone(),
+            unreachable_hosts: Default::default(),
         },
         signed_gossip: agr.signed_gossip.clone(),
         signature: agr.signature,

--- a/multinode_integration_tests/src/neighborhood_constructor.rs
+++ b/multinode_integration_tests/src/neighborhood_constructor.rs
@@ -247,7 +247,6 @@ fn from_masq_node_to_node_record(masq_node: &dyn MASQNode) -> NodeRecord {
     NodeRecord {
         inner: agr.inner.clone(),
         metadata: NodeRecordMetadata {
-            desirable_for_exit: true,
             last_update: time_t_timestamp(),
             node_addr_opt: agr.node_addr_opt.clone(),
             unreachable_hosts: Default::default(),

--- a/node/src/neighborhood/mod.rs
+++ b/node/src/neighborhood/mod.rs
@@ -1181,7 +1181,6 @@ impl Neighborhood {
     // target in hops_remaining or more hops with no cycles, or from the origin hops_remaining hops
     // out into the MASQ Network. No round trips; if you want a round trip, call this method twice.
     // If the return value is None, no qualifying route was found.
-    // TODO: Add a parameter for host_name
     fn find_best_route_segment<'a>(
         &'a self,
         source: &'a PublicKey,

--- a/node/src/neighborhood/mod.rs
+++ b/node/src/neighborhood/mod.rs
@@ -337,17 +337,18 @@ impl Handler<NodeRecordMetadataMessage> for Neighborhood {
     type Result = ();
 
     fn handle(&mut self, msg: NodeRecordMetadataMessage, _ctx: &mut Self::Context) -> Self::Result {
-        match msg {
-            NodeRecordMetadataMessage::Desirable(public_key, desirable) => {
-                if let Some(node_record) = self.neighborhood_database.node_by_key_mut(&public_key) {
-                    debug!(
-                        self.logger,
-                        "About to set desirable '{}' for '{:?}'", desirable, public_key
-                    );
-                    node_record.set_desirable_for_exit(desirable);
-                };
-            }
-        };
+        todo!("rewrite how this is handled");
+        // match msg {
+        //     NodeRecordMetadataMessage::Desirable(public_key, desirable) => {
+        //         if let Some(node_record) = self.neighborhood_database.node_by_key_mut(&public_key) {
+        //             debug!(
+        //                 self.logger,
+        //                 "About to set desirable '{}' for '{:?}'", desirable, public_key
+        //             );
+        //             node_record.set_desirable_for_exit(desirable);
+        //         };
+        //     }
+        // };
     }
 }
 
@@ -1122,6 +1123,7 @@ impl Neighborhood {
         payload_size: usize,
         link_type: LinkType,
     ) -> i64 {
+        todo!("modify how the undesirability is calculated");
         let (per_byte, per_cores) = match link_type {
             LinkType::Relay => (
                 node_record.inner.rate_pack.routing_byte_rate,
@@ -1141,6 +1143,15 @@ impl Neighborhood {
                 0
             };
         rate_undesirability + desirable_undesirability
+
+        // TODO: Uncomment these lines while test driving this code
+        // if let LinkType::Exit(link_name) = link_type {
+        //     if node_record.metadata.unreachable_hosts.contains(&link_name) {
+        //         return rate_undesirability + UNDESIRABLE_FOR_EXIT_PENALTY;
+        //     }
+        // }
+
+        // rate_undesirability
     }
 
     fn is_orig_node_on_back_leg(
@@ -1479,6 +1490,7 @@ pub fn regenerate_signed_gossip(
 enum LinkType {
     Relay,
     Exit,
+    // Exit(String), // TODO: Change above variant to this
     Origin,
 }
 

--- a/node/src/neighborhood/mod.rs
+++ b/node/src/neighborhood/mod.rs
@@ -2650,8 +2650,7 @@ mod tests {
         subject.consuming_wallet_opt = None;
         // These happen to be extracted in the desired order. We could not think of a way to guarantee it.
         let desirable_exit_node = make_node_record(2345, false);
-        let mut undesirable_exit_node = make_node_record(3456, true);
-        undesirable_exit_node.set_desirable_for_exit(false);
+        let undesirable_exit_node = make_node_record(3456, true);
         let originating_node = &subject.neighborhood_database.root().clone();
         {
             let db = &mut subject.neighborhood_database;
@@ -2853,8 +2852,7 @@ mod tests {
         let q = &make_node_record(3456, true);
         let r = &make_node_record(4567, false);
         let s = &make_node_record(5678, false);
-        let mut t = make_node_record(7777, false);
-        t.set_desirable_for_exit(false);
+        let t = make_node_record(7777, false);
         {
             let db = &mut subject.neighborhood_database;
             db.add_node(q.clone()).unwrap();
@@ -3268,7 +3266,6 @@ mod tests {
     fn compute_undesirability_for_relay_nodes() {
         let subject = make_standard_subject();
         let mut node_record = make_node_record(1, false);
-        node_record.metadata.desirable_for_exit = true; // not used as exit: irrelevant
         node_record.inner.rate_pack = RatePack {
             routing_byte_rate: 100,
             routing_service_rate: 200,
@@ -3285,7 +3282,6 @@ mod tests {
     fn compute_undesirability_for_exit_nodes() {
         let subject = make_standard_subject();
         let mut node_record = make_node_record(1, false);
-        node_record.metadata.desirable_for_exit = true; // used as exit, but leave out penalty for now
         node_record.inner.rate_pack = RatePack {
             routing_byte_rate: 123456,
             routing_service_rate: 234567,
@@ -3302,7 +3298,6 @@ mod tests {
     fn compute_undesirability_for_origin() {
         let subject = make_standard_subject();
         let mut node_record = make_node_record(1, false);
-        node_record.metadata.desirable_for_exit = true; // not used as exit: irrelevant
         node_record.inner.rate_pack = RatePack {
             routing_byte_rate: 123456,
             routing_service_rate: 234567,
@@ -3322,7 +3317,6 @@ mod tests {
         let mut unreachable_hosts = HashSet::new();
         unreachable_hosts.insert(unreachable_host.clone());
         let mut node_record = make_node_record(1, false);
-        node_record.metadata.desirable_for_exit = false; // used as exit: penalty is effective
         node_record.metadata.unreachable_hosts = unreachable_hosts;
         node_record.inner.rate_pack = RatePack {
             routing_byte_rate: 123456,

--- a/node/src/neighborhood/mod.rs
+++ b/node/src/neighborhood/mod.rs
@@ -344,14 +344,11 @@ impl Handler<NodeRecordMetadataMessage> for Neighborhood {
                     .neighborhood_database
                     .node_by_key_mut(&public_key)
                     .unwrap_or_else(|| panic!("No Node Record found for public_key: {public_key}"));
-                node_record
-                    .metadata
-                    .unreachable_hosts
-                    .insert(host_name.clone());
                 debug!(
                     self.logger,
-                    "Host {host_name} is marked unreachable for the node with public key {public_key}"
+                     "Marking host {host_name} unreachable for the Node with public key {public_key}"
                 );
+                node_record.metadata.unreachable_hosts.insert(host_name);
             }
         }
     }

--- a/node/src/neighborhood/mod.rs
+++ b/node/src/neighborhood/mod.rs
@@ -5088,7 +5088,7 @@ mod tests {
                 .unreachable_hosts
                 .contains(&unreachable_host));
             TestLogHandler::new().exists_log_matching(&format!(
-                "Host facebook.com is marked unreachable for the node with public key ZXhpdF9ub2Rl"
+                "DEBUG: Neighborhood: Marking host {unreachable_host} unreachable for the Node with public key {public_key}"
             ));
         });
         addr.try_send(AssertionsMessage { assertions }).unwrap();

--- a/node/src/neighborhood/node_record.rs
+++ b/node/src/neighborhood/node_record.rs
@@ -329,7 +329,18 @@ pub struct NodeRecordMetadata {
     pub desirable_for_exit: bool,
     pub last_update: u32,
     pub node_addr_opt: Option<NodeAddr>,
+    pub unreachable_hosts: HashSet<String>,
 }
+
+/*
+ORIGINATING     RELAY               EXIT
+facebook.com    facebook.com        baofeng.com
+twitter.com     wikipedia.com
+
+
+
+
+*/
 
 impl NodeRecordMetadata {
     pub fn new() -> NodeRecordMetadata {
@@ -337,6 +348,7 @@ impl NodeRecordMetadata {
             desirable_for_exit: true,
             last_update: time_t_timestamp(),
             node_addr_opt: None,
+            unreachable_hosts: Default::default(),
         }
     }
 }

--- a/node/src/neighborhood/node_record.rs
+++ b/node/src/neighborhood/node_record.rs
@@ -332,16 +332,6 @@ pub struct NodeRecordMetadata {
     pub unreachable_hosts: HashSet<String>,
 }
 
-/*
-ORIGINATING     RELAY               EXIT
-facebook.com    facebook.com        baofeng.com
-twitter.com     wikipedia.com
-
-
-
-
-*/
-
 impl NodeRecordMetadata {
     pub fn new() -> NodeRecordMetadata {
         NodeRecordMetadata {

--- a/node/src/neighborhood/node_record.rs
+++ b/node/src/neighborhood/node_record.rs
@@ -244,14 +244,6 @@ impl NodeRecord {
         &self.inner.rate_pack
     }
 
-    pub fn is_desirable_for_exit(&self) -> bool {
-        self.metadata.desirable_for_exit
-    }
-
-    pub fn set_desirable_for_exit(&mut self, is_desirable_for_exit: bool) {
-        self.metadata.desirable_for_exit = is_desirable_for_exit
-    }
-
     pub fn update(&mut self, agr: AccessibleGossipRecord) -> Result<(), String> {
         if &agr.inner.public_key != self.public_key() {
             return Err(format!(
@@ -326,7 +318,6 @@ impl TryFrom<&GossipNodeRecord> for NodeRecord {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 pub struct NodeRecordMetadata {
-    pub desirable_for_exit: bool,
     pub last_update: u32,
     pub node_addr_opt: Option<NodeAddr>,
     pub unreachable_hosts: HashSet<String>,
@@ -335,7 +326,6 @@ pub struct NodeRecordMetadata {
 impl NodeRecordMetadata {
     pub fn new() -> NodeRecordMetadata {
         NodeRecordMetadata {
-            desirable_for_exit: true,
             last_update: time_t_timestamp(),
             node_addr_opt: None,
             unreachable_hosts: Default::default(),
@@ -804,36 +794,6 @@ mod tests {
         assert_eq!(
             this_node.earning_wallet(),
             Wallet::from_str("0x546900db8d6e0937497133d1ae6fdf5f4b75bcd0").unwrap()
-        );
-    }
-
-    #[test]
-    fn set_desirable_when_no_change_from_default() {
-        let mut this_node = make_node_record(5432, true);
-
-        assert!(
-            this_node.is_desirable_for_exit(),
-            "initial state should have been desirable"
-        );
-        this_node.set_desirable_for_exit(true);
-        assert!(
-            this_node.is_desirable_for_exit(),
-            "Should be desirable after being set to true."
-        );
-    }
-
-    #[test]
-    fn set_desirable_to_false() {
-        let mut this_node = make_node_record(5432, true);
-
-        assert!(
-            this_node.is_desirable_for_exit(),
-            "initial state should have been desirable"
-        );
-        this_node.set_desirable_for_exit(false);
-        assert!(
-            !this_node.is_desirable_for_exit(),
-            "Should be undesirable after being set to false."
         );
     }
 

--- a/node/src/proxy_server/mod.rs
+++ b/node/src/proxy_server/mod.rs
@@ -279,7 +279,7 @@ impl ProxyServer {
                 })
                 .clone()
         };
-        let host_name = match &return_route_info.server_name {
+        let host_name = match &return_route_info.server_name_opt {
             Some(name) => name.clone(),
             None => UNSPECIFIED_SERVER.to_string(),
         };
@@ -311,7 +311,7 @@ impl ProxyServer {
                             .server_impersonator()
                             .dns_resolution_failure_response(
                                 &exit_public_key,
-                                return_route_info.server_name.clone(),
+                                return_route_info.server_name_opt.clone(),
                             ),
                     })
                     .expect("Dispatcher is dead");
@@ -555,7 +555,7 @@ impl ProxyServer {
                     return_route_id,
                     expected_services: back,
                     protocol: args.common.payload.protocol,
-                    server_name: args.common.payload.target_hostname.clone(),
+                    server_name_opt: args.common.payload.target_hostname.clone(),
                 };
                 debug!(
                     args.logger,
@@ -1449,7 +1449,7 @@ mod tests {
                 return_route_id: 1234,
                 expected_services: vec![ExpectedService::Nothing],
                 protocol: ProxyProtocol::TLS,
-                server_name: None,
+                server_name_opt: None,
             },
         );
         let subject_addr: Addr<ProxyServer> = subject.start();
@@ -2549,7 +2549,7 @@ mod tests {
                 return_route_id: 0,
                 expected_services: vec![ExpectedService::Nothing],
                 protocol: ProxyProtocol::HTTP,
-                server_name: Some("nowhere.com".to_string())
+                server_name_opt: Some("nowhere.com".to_string())
             }
         );
         let record = recording.get_record::<StreamShutdownMsg>(1);
@@ -2824,7 +2824,7 @@ mod tests {
                 ),
             ],
             protocol: ProxyProtocol::HTTP,
-            server_name: None,
+            server_name_opt: None,
         };
 
         subject.report_response_services_consumed(&add_return_route_message, 1234, 3456);
@@ -3277,7 +3277,7 @@ mod tests {
                 return_route_id: 1234,
                 expected_services: vec![ExpectedService::Nothing],
                 protocol: ProxyProtocol::TLS,
-                server_name: None,
+                server_name_opt: None,
             },
         );
         let subject_addr: Addr<ProxyServer> = subject.start();
@@ -3348,7 +3348,7 @@ mod tests {
                 return_route_id: 1234,
                 expected_services: vec![],
                 protocol: ProxyProtocol::HTTP,
-                server_name: None,
+                server_name_opt: None,
             },
         );
         let client_response_payload = ClientResponsePayload_0v1 {
@@ -3422,7 +3422,7 @@ mod tests {
                     ExpectedService::Nothing,
                 ],
                 protocol: ProxyProtocol::TLS,
-                server_name: None,
+                server_name_opt: None,
             },
         );
         let incoming_route_g_wallet = make_wallet("G Earning");
@@ -3454,7 +3454,7 @@ mod tests {
                     ExpectedService::Nothing,
                 ],
                 protocol: ProxyProtocol::TLS,
-                server_name: None,
+                server_name_opt: None,
             },
         );
         let subject_addr: Addr<ProxyServer> = subject.start();
@@ -3619,7 +3619,7 @@ mod tests {
                     ),
                 ],
                 protocol: ProxyProtocol::TLS,
-                server_name: None,
+                server_name_opt: None,
             },
         );
         let subject_addr: Addr<ProxyServer> = subject.start();
@@ -3726,7 +3726,7 @@ mod tests {
                     rate_pack(10),
                 )],
                 protocol: ProxyProtocol::HTTP,
-                server_name: Some("server.com".to_string()),
+                server_name_opt: Some("server.com".to_string()),
             })
             .unwrap();
         subject_addr.try_send(expired_cores_package).unwrap();
@@ -3797,7 +3797,7 @@ mod tests {
                     ExpectedService::Nothing,
                 ],
                 protocol: ProxyProtocol::TLS,
-                server_name: Some("server.com".to_string()),
+                server_name_opt: Some("server.com".to_string()),
             },
         );
         let subject_addr: Addr<ProxyServer> = subject.start();
@@ -3885,7 +3885,7 @@ mod tests {
                     rate_pack(10),
                 )],
                 protocol: ProxyProtocol::HTTP,
-                server_name: Some("server.com".to_string()),
+                server_name_opt: Some("server.com".to_string()),
             },
         );
         let subject_addr: Addr<ProxyServer> = subject.start();
@@ -3951,7 +3951,7 @@ mod tests {
                     rate_pack(10),
                 )],
                 protocol: ProxyProtocol::HTTP,
-                server_name: None,
+                server_name_opt: None,
             },
         );
         let subject_addr: Addr<ProxyServer> = subject.start();
@@ -4010,7 +4010,7 @@ mod tests {
                     rate_pack(10),
                 )],
                 protocol: ProxyProtocol::HTTP,
-                server_name: Some("server.com".to_string()),
+                server_name_opt: Some("server.com".to_string()),
             },
         );
         let subject_addr: Addr<ProxyServer> = subject.start();
@@ -4082,7 +4082,7 @@ mod tests {
                     rate_pack(10),
                 )],
                 protocol: ProxyProtocol::HTTP,
-                server_name: None,
+                server_name_opt: None,
             },
         );
 
@@ -4165,7 +4165,7 @@ mod tests {
                 return_route_id: 1234,
                 expected_services: vec![ExpectedService::Nothing, ExpectedService::Nothing],
                 protocol: ProxyProtocol::HTTP,
-                server_name: None,
+                server_name_opt: None,
             },
         );
         let dns_resolve_failure = DnsResolveFailure_0v1::new(stream_key);
@@ -4210,7 +4210,7 @@ mod tests {
                 return_route_id: 4321,
                 expected_services: vec![ExpectedService::Nothing],
                 protocol: ProxyProtocol::HTTP,
-                server_name: None,
+                server_name_opt: None,
             },
         );
         let subject_addr: Addr<ProxyServer> = subject.start();
@@ -4400,7 +4400,7 @@ mod tests {
                     return_route_id: 1234,
                     expected_services: vec![],
                     protocol: ProxyProtocol::TLS,
-                    server_name: None,
+                    server_name_opt: None,
                 },
             );
             let subject_addr: Addr<ProxyServer> = subject.start();

--- a/node/src/proxy_server/mod.rs
+++ b/node/src/proxy_server/mod.rs
@@ -3925,7 +3925,7 @@ mod tests {
     fn handle_dns_resolve_failure_does_not_sends_message_to_neighborhood_when_server_is_not_specified(
     ) {
         let system = System::new("test");
-        let (neighborhood_mock, _, neighborhood_log_arc) = make_recorder();
+        let (neighborhood, _, neighborhood_recording_arc) = make_recorder();
         let cryptde = main_cryptde();
         let mut subject = ProxyServer::new(
             cryptde,
@@ -3964,9 +3964,7 @@ mod tests {
                 dns_resolve_failure.into(),
                 0,
             );
-        let mut peer_actors = peer_actors_builder()
-            .neighborhood(neighborhood_mock)
-            .build();
+        let mut peer_actors = peer_actors_builder().neighborhood(neighborhood).build();
         peer_actors.proxy_server = ProxyServer::make_subs_from(&subject_addr);
 
         subject_addr.try_send(BindMessage { peer_actors }).unwrap();
@@ -3974,7 +3972,7 @@ mod tests {
 
         System::current().stop();
         system.run();
-        let neighborhood_recording = neighborhood_log_arc.lock().unwrap();
+        let neighborhood_recording = neighborhood_recording_arc.lock().unwrap();
         let record_opt = neighborhood_recording.get_record_opt::<NodeRecordMetadataMessage>(0);
         assert_eq!(record_opt, None);
     }

--- a/node/src/proxy_server/mod.rs
+++ b/node/src/proxy_server/mod.rs
@@ -1289,7 +1289,11 @@ mod tests {
         let record = recording.get_record::<RouteQueryMessage>(0);
         assert_eq!(
             record,
-            &RouteQueryMessage::data_indefinite_route_request(None, DEFAULT_MINIMUM_HOP_COUNT, 47)
+            &RouteQueryMessage::data_indefinite_route_request(
+                Some("nowhere.com".to_string()),
+                DEFAULT_MINIMUM_HOP_COUNT,
+                47
+            )
         );
         let recording = proxy_server_recording_arc.lock().unwrap();
         assert_eq!(recording.len(), 0);
@@ -1409,7 +1413,11 @@ mod tests {
         let neighborhood_record = neighborhood_recording.get_record::<RouteQueryMessage>(0);
         assert_eq!(
             neighborhood_record,
-            &RouteQueryMessage::data_indefinite_route_request(None, DEFAULT_MINIMUM_HOP_COUNT, 12)
+            &RouteQueryMessage::data_indefinite_route_request(
+                Some("realdomain.nu".to_string()),
+                DEFAULT_MINIMUM_HOP_COUNT,
+                12
+            )
         );
     }
 
@@ -1807,7 +1815,7 @@ mod tests {
                 minimum_hop_count: 0,
                 return_component_opt: Some(Component::ProxyServer),
                 payload_size: 47,
-                hostname_opt: None
+                hostname_opt: Some("nowhere.com".to_string())
             }
         );
         let dispatcher_recording = dispatcher_log_arc.lock().unwrap();
@@ -2198,7 +2206,11 @@ mod tests {
         let record = recording.get_record::<RouteQueryMessage>(0);
         assert_eq!(
             record,
-            &RouteQueryMessage::data_indefinite_route_request(None, 3, 47)
+            &RouteQueryMessage::data_indefinite_route_request(
+                Some("nowhere.com".to_string()),
+                3,
+                47
+            )
         );
     }
 

--- a/node/src/proxy_server/mod.rs
+++ b/node/src/proxy_server/mod.rs
@@ -322,7 +322,7 @@ impl ProxyServer {
             None => {
                 error!(self.logger,
                     "Discarding DnsResolveFailure message for {} from an unrecognized stream key {:?}",
-                    server_name_opt.unwrap_or("<unspecified_server>".to_string()),
+                    server_name_opt.unwrap_or_else(|| "<unspecified_server>".to_string()),
                     &response.stream_key
                 )
             }

--- a/node/src/proxy_server/mod.rs
+++ b/node/src/proxy_server/mod.rs
@@ -938,6 +938,7 @@ impl IBCDHelperReal {
     ) -> Result<(), String> {
         let common_args = args.common_opt.as_ref().expectv("TTH common");
         let pld = &common_args.payload;
+        let hostname_opt = pld.target_hostname.clone();
         debug!(
             args.logger,
             "Getting route and opening new stream with key {} to transmit: sequence {}, length {}",
@@ -949,6 +950,7 @@ impl IBCDHelperReal {
         tokio::spawn(
             route_source
                 .send(RouteQueryMessage::data_indefinite_route_request(
+                    hostname_opt,
                     if common_args.is_decentralized {
                         DEFAULT_MINIMUM_HOP_COUNT
                     } else {
@@ -1287,7 +1289,7 @@ mod tests {
         let record = recording.get_record::<RouteQueryMessage>(0);
         assert_eq!(
             record,
-            &RouteQueryMessage::data_indefinite_route_request(DEFAULT_MINIMUM_HOP_COUNT, 47)
+            &RouteQueryMessage::data_indefinite_route_request(None, DEFAULT_MINIMUM_HOP_COUNT, 47)
         );
         let recording = proxy_server_recording_arc.lock().unwrap();
         assert_eq!(recording.len(), 0);
@@ -1407,7 +1409,7 @@ mod tests {
         let neighborhood_record = neighborhood_recording.get_record::<RouteQueryMessage>(0);
         assert_eq!(
             neighborhood_record,
-            &RouteQueryMessage::data_indefinite_route_request(DEFAULT_MINIMUM_HOP_COUNT, 12)
+            &RouteQueryMessage::data_indefinite_route_request(None, DEFAULT_MINIMUM_HOP_COUNT, 12)
         );
     }
 
@@ -1805,6 +1807,7 @@ mod tests {
                 minimum_hop_count: 0,
                 return_component_opt: Some(Component::ProxyServer),
                 payload_size: 47,
+                hostname_opt: None
             }
         );
         let dispatcher_recording = dispatcher_log_arc.lock().unwrap();
@@ -1884,7 +1887,8 @@ mod tests {
                 target_component: Component::ProxyClient,
                 minimum_hop_count: 0,
                 return_component_opt: Some(Component::ProxyServer),
-                payload_size: 16
+                payload_size: 16,
+                hostname_opt: None
             }
         );
         let dispatcher_recording = dispatcher_log_arc.lock().unwrap();
@@ -2194,7 +2198,7 @@ mod tests {
         let record = recording.get_record::<RouteQueryMessage>(0);
         assert_eq!(
             record,
-            &RouteQueryMessage::data_indefinite_route_request(3, 47)
+            &RouteQueryMessage::data_indefinite_route_request(None, 3, 47)
         );
     }
 
@@ -2706,7 +2710,11 @@ mod tests {
         let record = recording.get_record::<RouteQueryMessage>(0);
         assert_eq!(
             record,
-            &RouteQueryMessage::data_indefinite_route_request(3, 47)
+            &RouteQueryMessage::data_indefinite_route_request(
+                Some("nowhere.com".to_string()),
+                3,
+                47
+            )
         );
         TestLogHandler::new()
             .exists_log_containing("ERROR: ProxyServer: Failed to find route to nowhere.com");
@@ -2878,7 +2886,11 @@ mod tests {
         let record = recording.get_record::<RouteQueryMessage>(0);
         assert_eq!(
             record,
-            &RouteQueryMessage::data_indefinite_route_request(3, 47)
+            &RouteQueryMessage::data_indefinite_route_request(
+                Some("nowhere.com".to_string()),
+                3,
+                47
+            )
         );
         TestLogHandler::new()
             .exists_log_containing("ERROR: ProxyServer: Failed to find route to nowhere.com");

--- a/node/src/proxy_server/mod.rs
+++ b/node/src/proxy_server/mod.rs
@@ -3919,7 +3919,7 @@ mod tests {
     }
 
     #[test]
-    fn handle_dns_resolve_failure_does_not_sends_message_to_neighborhood_when_server_is_not_specified(
+    fn handle_dns_resolve_failure_does_not_send_message_to_neighborhood_when_server_is_not_specified(
     ) {
         let system = System::new("test");
         let (neighborhood, _, neighborhood_recording_arc) = make_recorder();
@@ -3935,7 +3935,7 @@ mod tests {
         let socket_addr = SocketAddr::from_str("1.2.3.4:5678").unwrap();
         subject
             .keys_and_addrs
-            .insert(stream_key.clone(), socket_addr.clone());
+            .insert(stream_key.clone(), socket_addr);
         let exit_public_key = PublicKey::from(&b"exit_key"[..]);
         let exit_wallet = make_wallet("exit wallet");
         subject.route_ids_to_return_routes.insert(
@@ -4113,11 +4113,10 @@ mod tests {
         system.run();
 
         TestLogHandler::new().exists_log_containing(
-            format!(
+            &format!(
                 "Discarding DnsResolveFailure message for <unspecified_server> from an unrecognized stream key {:?}",
                 stream_key
             )
-            .as_str(),
         );
     }
 

--- a/node/src/sub_lib/neighborhood.rs
+++ b/node/src/sub_lib/neighborhood.rs
@@ -512,7 +512,6 @@ pub struct AskAboutDebutGossipMessage {
 pub struct NodeRecordMetadataMessage {
     pub public_key: PublicKey,
     pub unreachable_host_name_opt: Option<String>,
-    // Desirable(PublicKey, bool),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/node/src/sub_lib/neighborhood.rs
+++ b/node/src/sub_lib/neighborhood.rs
@@ -438,6 +438,7 @@ pub struct RouteQueryMessage {
     pub minimum_hop_count: usize,
     pub return_component_opt: Option<Component>,
     pub payload_size: usize,
+    pub hostname_opt: Option<String>,
 }
 
 impl Message for RouteQueryMessage {
@@ -446,6 +447,7 @@ impl Message for RouteQueryMessage {
 
 impl RouteQueryMessage {
     pub fn data_indefinite_route_request(
+        hostname_opt: Option<String>,
         minimum_hop_count: usize,
         payload_size: usize,
     ) -> RouteQueryMessage {
@@ -455,6 +457,7 @@ impl RouteQueryMessage {
             minimum_hop_count,
             return_component_opt: Some(Component::ProxyServer),
             payload_size,
+            hostname_opt,
         }
     }
 }
@@ -960,7 +963,7 @@ mod tests {
 
     #[test]
     fn data_indefinite_route_request() {
-        let result = RouteQueryMessage::data_indefinite_route_request(2, 7500);
+        let result = RouteQueryMessage::data_indefinite_route_request(None, 2, 7500);
 
         assert_eq!(
             result,
@@ -970,6 +973,7 @@ mod tests {
                 minimum_hop_count: 2,
                 return_component_opt: Some(Component::ProxyServer),
                 payload_size: 7500,
+                hostname_opt: None
             }
         );
     }

--- a/node/src/sub_lib/neighborhood.rs
+++ b/node/src/sub_lib/neighborhood.rs
@@ -506,8 +506,10 @@ pub struct AskAboutDebutGossipMessage {
 }
 
 #[derive(Clone, Debug, Message, PartialEq, Eq)]
-pub enum NodeRecordMetadataMessage {
-    Desirable(PublicKey, bool),
+pub struct NodeRecordMetadataMessage {
+    pub public_key: PublicKey,
+    pub unreachable_host_name_opt: Option<String>,
+    // Desirable(PublicKey, bool),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/node/src/sub_lib/neighborhood.rs
+++ b/node/src/sub_lib/neighborhood.rs
@@ -511,7 +511,12 @@ pub struct AskAboutDebutGossipMessage {
 #[derive(Clone, Debug, Message, PartialEq, Eq)]
 pub struct NodeRecordMetadataMessage {
     pub public_key: PublicKey,
-    pub unreachable_host_name_opt: Option<String>,
+    pub metadata_change: NRMetadataChange,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NRMetadataChange {
+    AddUnreachableHost { host_name: String },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/node/src/sub_lib/proxy_server.rs
+++ b/node/src/sub_lib/proxy_server.rs
@@ -60,7 +60,7 @@ pub struct AddReturnRouteMessage {
     pub return_route_id: u32,
     pub expected_services: Vec<ExpectedService>,
     pub protocol: ProxyProtocol,
-    pub server_name: Option<String>,
+    pub server_name_opt: Option<String>,
 }
 
 #[derive(Message, Debug, PartialEq, Eq)]

--- a/node/tests/contract_test.rs
+++ b/node/tests/contract_test.rs
@@ -134,7 +134,10 @@ fn masq_erc20_contract_exists_on_ethereum_mainnet_integration() {
 
 #[test]
 fn masq_erc20_contract_exists_on_ethereum_ropsten_integration() {
-    let blockchain_urls = vec!["https://ropsten.infura.io/v3/0ead23143b174f6983c76f69ddcf4026"];
+    let blockchain_urls = vec![
+        "https://ropsten.infura.io/v3/0ead23143b174f6983c76f69ddcf4026",
+        "https://rpc.ankr.com/eth_ropsten",
+    ];
     let chain = Chain::EthRopsten;
 
     assert_contract(blockchain_urls, &chain, "Shroud", 18)


### PR DESCRIPTION
This PR is a child of original PR GH-633 except it excludes the multinode test. The multinode test will get integrated to `master` under a different card.