### PR TITLE
GH-701: Annoying cargo manifest warnings

### DIFF
--- a/automap/Cargo.toml
+++ b/automap/Cargo.toml
@@ -3,7 +3,6 @@ name = "automap"
 version = "0.7.3"
 authors = ["Dan Wiebe <dnwiebe@gmail.com>", "MASQ"]
 license = "GPL-3.0-only"
-copyright = "Copyright (c) 2019-2021, MASQ (https://masq.ai) and/or its affiliates. All rights reserved."
 description = "Library full of code to make routers map ports through firewalls"
 edition = "2021"
 #workspace = "../node"

--- a/masq/Cargo.toml
+++ b/masq/Cargo.toml
@@ -3,7 +3,6 @@ name = "masq"
 version = "0.7.3"
 authors = ["Dan Wiebe <dnwiebe@gmail.com>", "MASQ"]
 license = "GPL-3.0-only"
-copyright = "Copyright (c) 2019, MASQ (https://masq.ai) and/or its affiliates. All rights reserved."
 description = "Reference implementation of user interface for MASQ Node"
 edition = "2021"
 workspace = "../node"

--- a/masq_lib/Cargo.toml
+++ b/masq_lib/Cargo.toml
@@ -3,7 +3,6 @@ name = "masq_lib"
 version = "0.7.3"
 authors = ["Dan Wiebe <dnwiebe@gmail.com>", "MASQ"]
 license = "GPL-3.0-only"
-copyright = "Copyright (c) 2019, MASQ (https://masq.ai) and/or its affiliates. All rights reserved."
 description = "Code common to Node and masq; also, temporarily, to dns_utility"
 edition = "2021"
 workspace = "../node"

--- a/multinode_integration_tests/Cargo.toml
+++ b/multinode_integration_tests/Cargo.toml
@@ -3,7 +3,6 @@ name = "multinode_integration_tests"
 version = "0.7.3"
 authors = ["Dan Wiebe <dnwiebe@gmail.com>", "MASQ"]
 license = "GPL-3.0-only"
-copyright = "Copyright (c) 2019, MASQ (https://masq.ai) and/or its affiliates. All rights reserved."
 description = ""
 edition = "2021"
 workspace = "../node"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,12 +3,10 @@ name = "node"
 version = "0.7.3"
 license = "GPL-3.0-only"
 authors = ["Dan Wiebe <dnwiebe@gmail.com>", "MASQ"]
-copyright = "Copyright (c) 2019, MASQ (https://masq.ai) and/or its affiliates. All rights reserved."
 description = "MASQ Node is the foundation of MASQ Network, an open-source network that allows anyone to allocate spare computing resources to make the internet a free and fair place for the entire world."
 edition = "2021"
 
 [workspace]
-#members = ["../masq_lib"]
 members = ["../multinode_integration_tests", "../masq_lib", "../masq"]
 
 [dependencies]
@@ -99,8 +97,6 @@ path = "src/main_win.rs"
 [lib]
 name = "node_lib"
 path = "src/lib.rs"
-
-cargo-bundle = "0.4.0"
 
 [features]
 expose_test_privates = []


### PR DESCRIPTION
The newer `cargo` (after September 2021) doesn't contain `copyright` and `cargo-bundle` as valid keys for the manifest file.

The suggestion is to use the copyright statement inside the source code files or Readme.

The `cargo-bundle` is also obsolete. The suggested alternatives on the internet are `wasm-pack`, `rustwasm/wasm-bindgen`, or `parcel-bundler`. 

Here is the list of valid keys for the manifest file - https://doc.rust-lang.org/cargo/reference/manifest.html?highlight=copyright#the-package-section