### PR TITLE
Gh 685 review2

### DIFF
--- a/masq_lib/src/shared_schema.rs
+++ b/masq_lib/src/shared_schema.rs
@@ -13,12 +13,12 @@ use lazy_static::lazy_static;
 pub const BLOCKCHAIN_SERVICE_HELP: &str =
     "The Ethereum client you wish to use to provide Blockchain \
      exit services from your MASQ Node (e.g. http://localhost:8545, \
-     https://ropsten.infura.io/v3/YOUR-PROJECT-ID, https://mainnet.infura.io/v3/YOUR-PROJECT-ID), \
-     https://base-mainnet.g.alchemy.com/v2/d66UL0lPrltmweEqVsv3opBSVI3wkL8I, \
-     https://polygon-mainnet.infura.io/v3/YOUR-PROJECT-ID \n This argument is mandatory, to ensure, you \
-     will not be deliquency banned due unable to pay your debts to MASQ network. If you are in region \
-     where you have no access to blockchain services, to create your own app, use one of following public \
-     endpoints for Base Mainnet (you need to specify Base Mainnet chain in the chain argument): \n\
+     https://ropsten.infura.io/v3/<api-key>, https://mainnet.infura.io/v3/<api-key>), \
+     https://base-mainnet.g.alchemy.com/<api-key>, https://polygon-mainnet.infura.io/v3/<api-key> \n \
+     This argument is mandatory, to ensure that you will not be deliquency banned due to being unable to \
+     pay your debts to MASQ network. If you are in a region where you have no access to blockchain \
+     services, to create your own app, use one of following the public endpoints for Base Mainnet \
+     (you need to specify `--chain base-mainnet` as the chain argument): \n\
      https://mainnet.base.org \nhttps://base.llamarpc.com \nhttps://1rpc.io/base \nhttps://base-rpc.publicnode.com";
 pub const CHAIN_HELP: &str =
     "The blockchain network MASQ Node will configure itself to use. You must ensure the \
@@ -737,12 +737,12 @@ mod tests {
             BLOCKCHAIN_SERVICE_HELP,
             "The Ethereum client you wish to use to provide Blockchain \
              exit services from your MASQ Node (e.g. http://localhost:8545, \
-             https://ropsten.infura.io/v3/YOUR-PROJECT-ID, https://mainnet.infura.io/v3/YOUR-PROJECT-ID), \
-             https://base-mainnet.g.alchemy.com/v2/d66UL0lPrltmweEqVsv3opBSVI3wkL8I, \
-             https://polygon-mainnet.infura.io/v3/YOUR-PROJECT-ID \n This argument is mandatory, to ensure, you \
-             will not be deliquency banned due unable to pay your debts to MASQ network. If you are in region \
-             where you have no access to blockchain services, to create your own app, use one of following public \
-             endpoints for Base Mainnet (you need to specify Base Mainnet chain in the chain argument): \n\
+             https://ropsten.infura.io/v3/<api-key>, https://mainnet.infura.io/v3/<api-key>), \
+             https://base-mainnet.g.alchemy.com/<api-key>, https://polygon-mainnet.infura.io/v3/<api-key> \n \
+             This argument is mandatory, to ensure that you will not be deliquency banned due to being unable to \
+             pay your debts to MASQ network. If you are in a region where you have no access to blockchain \
+             services, to create your own app, use one of following the public endpoints for Base Mainnet \
+             (you need to specify `--chain base-mainnet` as the chain argument): \n\
              https://mainnet.base.org \nhttps://base.llamarpc.com \nhttps://1rpc.io/base \nhttps://base-rpc.publicnode.com"
         );
         assert_eq!(

--- a/node/src/node_configurator/unprivileged_parse_args_configuration.rs
+++ b/node/src/node_configurator/unprivileged_parse_args_configuration.rs
@@ -1251,7 +1251,7 @@ mod tests {
             .unwrap_err();
 
         let expected = MultiConfig::make_configurator_error(Error {
-            message: "The following required arguments were not provided: --blockchain-service-url USAGE: --blockchain-service-url <blockchain-service-url>".to_string(),
+            message: "The following required argument was not provided: --blockchain-service-url USAGE: --blockchain-service-url <blockchain-service-url>".to_string(),
             kind: clap::ErrorKind::ArgumentNotFound,
             info: Some(vec!["<blockchain-service-url>".to_string()]),
         });

--- a/node/src/node_configurator/unprivileged_parse_args_configuration.rs
+++ b/node/src/node_configurator/unprivileged_parse_args_configuration.rs
@@ -48,7 +48,7 @@ pub trait UnprivilegedParseArgsConfiguration {
                 Ok(None) => {
                     if self.blockchain_service_url_error(multi_config) {
                         return Err(MultiConfig::make_configurator_error(Error {
-                                message: "The following required arguments were not provided: --blockchain-service-url USAGE: --blockchain-service-url <blockchain-service-url>".to_string(),
+                                message: "The following required argument was not provided: --blockchain-service-url USAGE: --blockchain-service-url <blockchain-service-url>".to_string(),
                                 kind: clap::ErrorKind::ArgumentNotFound,
                                 info: Some(vec!["<blockchain-service-url>".to_string()]),
                             }));
@@ -56,7 +56,7 @@ pub trait UnprivilegedParseArgsConfiguration {
                         None
                     }
                 }
-                Err(pce) => return Err(pce.into_configurator_error("gas-price")),
+                Err(pce) => return Err(pce.into_configurator_error("blockchain-service-url")),
             }
         };
         unprivileged_config.clandestine_port_opt = value_m!(multi_config, "clandestine-port", u16);
@@ -82,11 +82,11 @@ pub trait UnprivilegedParseArgsConfiguration {
     }
 
     fn blockchain_service_url_error(&self, multi_config: &MultiConfig) -> bool {
-        let zerohop =
+        let no_zerohop =
             value_m!(multi_config, "neighborhood-mode", String) != Some("zero-hop".to_string());
-        let fake_public_key = value_m!(multi_config, "fake-public-key", String) == None;
-        let crash_point = value_m!(multi_config, "crash-point", String) == None;
-        zerohop && fake_public_key && crash_point
+        let no_fake_public_key = value_m!(multi_config, "fake-public-key", String) == None;
+        let no_crash_point = value_m!(multi_config, "crash-point", String) == None;
+        no_zerohop && no_fake_public_key && no_crash_point
     }
 
     fn get_past_neighbors(
@@ -1263,12 +1263,33 @@ mod tests {
     fn unprivileged_parse_args_without_blockchain_service_url_but_not_bsu_error_returns_ok() {
         running_test();
         let set_past_neighbors_params_arc = Arc::new(Mutex::new(vec![]));
-        let mut config = BootstrapperConfig::new();
-        let mut persistent_config = configure_default_persistent_config(
+        let config = BootstrapperConfig::new();
+        let persistent_config = configure_default_persistent_config(
             RATE_PACK | ACCOUNTANT_CONFIG_PARAMS | MAPPING_PROTOCOL,
         )
         .set_past_neighbors_params(&set_past_neighbors_params_arc)
         .set_past_neighbors_result(Ok(()));
+        let exeption_params = vec![
+            ("--fake-public-key", "booga"),
+            ("--crash-point", "Error"),
+            ("--neighborhood-mode", "zero-hop"),
+        ];
+
+        for exeption_param in exeption_params {
+            create_and_assert_multiconfig(
+                config.clone(),
+                persistent_config.clone(),
+                exeption_param,
+            );
+        }
+    }
+
+    fn create_and_assert_multiconfig(
+        mut config: BootstrapperConfig,
+        mut persistent_config: PersistentConfigurationMock,
+        exeption_param: (&str, &str),
+    ) {
+        let subject = UnprivilegedParseArgsConfigurationDaoReal {};
         let multi_config = make_simplified_multi_config([
             "--chain",
             "eth-ropsten",
@@ -1276,11 +1297,9 @@ mod tests {
             "masq://eth-ropsten:UJNoZW5p-PDVqEjpr3b_8jZ_93yPG8i5dOAgE1bhK_A@2.3.4.5:2345",
             "--db-password",
             "password",
-            "--fake-public-key",
-            "booga",
+            exeption_param.0,
+            exeption_param.1,
         ]);
-        let subject = UnprivilegedParseArgsConfigurationDaoReal {};
-
         let result = subject.unprivileged_parse_args(
             &multi_config,
             &mut config,

--- a/node/tests/connection_shutdown_test.rs
+++ b/node/tests/connection_shutdown_test.rs
@@ -21,11 +21,7 @@ fn proxy_client_stream_reader_dies_when_client_stream_is_killed_integration() {
     let ui_port = find_free_port();
     let _node = utils::MASQNode::start_standard(
         "proxy_client_stream_reader_dies_when_client_stream_is_killed_integration",
-        Some(
-            CommandConfig::new()
-                .pair("--blockchain-service-url", "https://booga.com")
-                .pair("--ui-port", &ui_port.to_string()),
-        ),
+        Some(CommandConfig::new().pair("--ui-port", &ui_port.to_string())),
         true,
         true,
         false,

--- a/node/tests/dns_resolve_failure_test.rs
+++ b/node/tests/dns_resolve_failure_test.rs
@@ -2,7 +2,6 @@
 
 pub mod utils;
 
-use crate::utils::CommandConfig;
 use node_lib::test_utils::{assert_string_contains, read_until_timeout};
 use std::io::Write;
 use std::net::{SocketAddr, TcpStream};
@@ -13,7 +12,7 @@ use std::time::Duration;
 fn dns_resolve_failure_http_response_integration() {
     let _node_to_test_against = utils::MASQNode::start_standard(
         "dns_resolve_failure_http_response_integration",
-        Some(CommandConfig::new().pair("--blockchain-service-url", "https://booga.com")),
+        None,
         true,
         true,
         false,
@@ -36,7 +35,7 @@ fn dns_resolve_failure_http_response_integration() {
 fn dns_resolve_failure_tls_response_integration() {
     let _node_to_test_against = utils::MASQNode::start_standard(
         "dns_resolve_failure_tls_response_integration",
-        Some(CommandConfig::new().pair("--blockchain-service-url", "https://booga.com")),
+        None,
         true,
         true,
         false,

--- a/node/tests/dump_configuration_test.rs
+++ b/node/tests/dump_configuration_test.rs
@@ -21,7 +21,6 @@ fn dump_configuration_with_an_existing_database_integration() {
             test_name,
             Some(
                 CommandConfig::new()
-                    .pair("--blockchain-service-url", "https://booga.com")
                     .pair("--ui-port", &port.to_string())
                     .pair("--chain", "polygon-amoy"),
             ),

--- a/node/tests/financials_test.rs
+++ b/node/tests/financials_test.rs
@@ -73,11 +73,7 @@ fn financials_command_retrieves_payable_and_receivable_records_integration() {
         .unwrap();
     let mut node = MASQNode::start_standard(
         test_name,
-        Some(
-            CommandConfig::new()
-                .pair("--blockchain-service-url", "https://booga.com")
-                .pair("--ui-port", &port.to_string()),
-        ),
+        Some(CommandConfig::new().pair("--ui-port", &port.to_string())),
         false,
         true,
         false,

--- a/node/tests/http_through_node_test.rs
+++ b/node/tests/http_through_node_test.rs
@@ -2,7 +2,6 @@
 
 pub mod utils;
 
-use crate::utils::CommandConfig;
 use node_lib::test_utils::read_until_timeout;
 use std::io::Write;
 use std::net::SocketAddr;
@@ -15,7 +14,7 @@ use std::time::Duration;
 fn http_through_node_integration() {
     let _node = utils::MASQNode::start_standard(
         "http_through_node_integration",
-        Some(CommandConfig::new().pair("--blockchain-service-url", "https://booga.com")),
+        None,
         true,
         true,
         false,

--- a/node/tests/initialization_test.rs
+++ b/node/tests/initialization_test.rs
@@ -152,12 +152,11 @@ fn wait_for_process_end(process_id: u32) {
 
 #[test]
 fn incomplete_node_descriptor_is_refused_integration() {
-    let chain_identifier = "base-mainnet";
+    let chain_identifier = DEFAULT_CHAIN.rec().literal_identifier;
     let mut node = utils::MASQNode::start_standard(
         "incomplete_node_descriptor_is_refused_integration",
         Some(
             CommandConfig::new()
-                .pair("--blockchain-service-url", "https://booga.com")
                 .pair(
                     "--neighbors",
                     &format!("masq://{chain_identifier}:12345vhVbmVyGejkYUkmftF09pmGZGKg_PzRNnWQxFw@12.23.34.45:5678,masq://{chain_identifier}:abJ5XvhVbmVyGejkYUkmftF09pmGZGKg_PzRNnWQxFw@:")
@@ -225,7 +224,6 @@ fn requested_chain_meets_different_db_chain_and_panics_integration() {
             test_name,
             Some(
                 CommandConfig::new()
-                    .pair("--blockchain-service-url", "https://booga.com")
                     .pair("--ui-port", &port.to_string())
                     .pair("--chain", &chain_literal),
             ),
@@ -271,7 +269,6 @@ fn requested_chain_meets_different_db_chain_and_panics_integration() {
 #[test]
 fn node_creates_log_file_with_heading_integration() {
     let config = CommandConfig::new()
-        .pair("--blockchain-service-url", "https://booga.com")
         .pair("--neighborhood-mode", "standard")
         .pair("--ip", "1.0.0.1")
         .pair(

--- a/node/tests/node_exits_from_future_panic_test.rs
+++ b/node/tests/node_exits_from_future_panic_test.rs
@@ -41,7 +41,6 @@ fn node_logs_panic_integration() {
         "Could not create chain directory inside node_logs_panic_integration home/MASQ directory",
     );
     let panic_config = CommandConfig::new()
-        .pair("--blockchain-service-url", "https://booga.com")
         .pair("--crash-point", "panic")
         .pair("--chain", "polygon-mainnet")
         .pair("--data-directory", data_directory.to_str().unwrap());
@@ -68,11 +67,7 @@ const STAT_FORMAT_PARAM_NAME: &str = "-f";
 fn node_logfile_does_not_belong_to_root_integration() {
     let mut node = MASQNode::start_standard(
         "node_logfile_does_not_belong_to_root_integration",
-        Some(
-            CommandConfig::new()
-                .pair("--blockchain-service-url", "https://booga.com")
-                .pair("--chain", "polygon-amoy"),
-        ),
+        Some(CommandConfig::new().pair("--chain", "polygon-amoy")),
         true,
         true,
         false,

--- a/node/tests/tls_through_node_test.rs
+++ b/node/tests/tls_through_node_test.rs
@@ -2,7 +2,6 @@
 
 pub mod utils;
 
-use crate::utils::CommandConfig;
 use native_tls::TlsConnector;
 use native_tls::{HandshakeError, MidHandshakeTlsStream, TlsStream};
 use node_lib::test_utils::*;
@@ -17,7 +16,7 @@ use std::time::Duration;
 fn tls_through_node_integration() {
     let _node = utils::MASQNode::start_standard(
         "tls_through_node_integration",
-        Some(CommandConfig::new().pair("--blockchain-service-url", "https://booga.com")),
+        None,
         true,
         true,
         false,

--- a/node/tests/ui_gateway_test.rs
+++ b/node/tests/ui_gateway_test.rs
@@ -29,7 +29,6 @@ fn ui_requests_something_and_gets_corresponding_response_integration() {
         test_name,
         Some(
             CommandConfig::new()
-                .pair("--blockchain-service-url", "https://booga.com")
                 .pair("--ui-port", &port.to_string())
                 .pair(
                     "--data-directory",
@@ -64,7 +63,6 @@ fn log_broadcasts_are_correctly_received_integration() {
         "log_broadcasts_are_correctly_received",
         Some(
             CommandConfig::new()
-                .pair("--blockchain-service-url", "https://booga.com")
                 .pair("--ui-port", &port.to_string())
                 .pair("--chain", "polygon-mainnet"),
         ),
@@ -210,7 +208,6 @@ fn cleanup_after_deceased_clients_integration() {
         test_name,
         Some(
             CommandConfig::new()
-                .pair("--blockchain-service-url", "https://booga.com")
                 .pair("--chain", DEFAULT_CHAIN.rec().literal_identifier)
                 .pair("--ui-port", &port.to_string()),
         ),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies blockchain service URL help text and error messaging, fixes a misattributed configurator error, and updates tests to no longer pass --blockchain-service-url where unnecessary.
> 
> - **CLI/Help**:
>   - Update `BLOCKCHAIN_SERVICE_HELP` with `<api-key>` placeholders, improved grammar, and explicit `--chain base-mainnet` guidance.
> - **Error handling**:
>   - Change required-arg message to singular phrasing; fix `into_configurator_error` target from `gas-price` to `blockchain-service-url`.
> - **Unit/Integration Tests**:
>   - Adjust expectations for updated help/error strings.
>   - Add helper to validate exceptions suppressing blockchain URL requirement.
>   - Remove `--blockchain-service-url` from many `MASQNode::start_*` calls; minor arg tweaks (e.g., chain identifier from `DEFAULT_CHAIN`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 317243fc4365264272706362002f108b2c354f17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->