### PR TITLE
Refine regex for max block count extraction and add test

### DIFF
--- a/node/src/blockchain/blockchain_bridge.rs
+++ b/node/src/blockchain/blockchain_bridge.rs
@@ -1541,7 +1541,7 @@ mod tests {
         system.run();
         let after = SystemTime::now();
         let expected_transactions = RetrievedBlockchainTransactions {
-            new_start_block: BlockMarker::Value(42 + 9_000_000 + 1),
+            new_start_block: BlockMarker::Value(42 + 9_000_000),
             transactions: vec![
                 BlockchainTransaction {
                     block_number: 6040059,
@@ -1742,7 +1742,7 @@ mod tests {
         let received_payments_message = accountant_recording.get_record::<ReceivedPayments>(0);
         check_timestamp(before, received_payments_message.timestamp, after);
         let expected_transactions = RetrievedBlockchainTransactions {
-            new_start_block: BlockMarker::Value(6 + 5000 + 1),
+            new_start_block: BlockMarker::Value(6 + 5000),
             transactions: vec![BlockchainTransaction {
                 block_number: 2000,
                 from: earning_wallet.clone(),

--- a/node/src/blockchain/blockchain_bridge.rs
+++ b/node/src/blockchain/blockchain_bridge.rs
@@ -507,8 +507,8 @@ impl BlockchainBridge {
 
     pub fn extract_max_block_count(error: BlockchainError) -> Option<u64> {
         let regex_result =
-            Regex::new(r".* (max: |allowed for your plan: |is limited to |block range limit \(|exceeds max block range )(?P<max_block_count>\d+).*")
-                .expect("Invalid regex");
+            Regex::new(r".* (max: |allowed for your plan: |is limited to |block range limit \(|exceeds max block range |maximum allowed is )(?P<max_block_count>\d+).*")
+        .expect("Invalid regex");
         let max_block_count = match error {
             BlockchainError::QueryFailed(msg) => match regex_result.captures(msg.as_str()) {
                 Some(captures) => match captures.name("max_block_count") {
@@ -2199,6 +2199,15 @@ mod tests {
         let max_block_count = BlockchainBridge::extract_max_block_count(result);
 
         assert_eq!(Some(100000), max_block_count);
+    }
+
+    #[test]
+    fn extract_max_block_range_for_nodies_error_response_v2() {
+        let result = BlockchainError::QueryFailed("RPC error: Error { code: ServerError(-32001), message: \"Block range too large: maximum allowed is 20000 blocks\", data: None }".to_string());
+
+        let max_block_count = BlockchainBridge::extract_max_block_count(result);
+
+        assert_eq!(Some(20000), max_block_count);
     }
 
     #[test]

--- a/node/src/blockchain/blockchain_interface/blockchain_interface_web3/mod.rs
+++ b/node/src/blockchain/blockchain_interface/blockchain_interface_web3/mod.rs
@@ -517,8 +517,8 @@ mod tests {
         let start_block_marker = BlockMarker::Value(42);
         let scan_range = BlockScanRange::Range(1000);
         let block_response = "0x7d0"; // 2_000
-        let expected_new_start_block = BlockMarker::Value(42 + 1000 + 1);
-        let expected_log = "from start block: Number(42) to end block: Number(1042)";
+        let expected_new_start_block = BlockMarker::Value(42 + 1000);
+        let expected_log = "from start block: Number(42) to end block: Number(1041)";
         assert_on_retrieves_transactions(
             start_block_marker,
             scan_range,
@@ -1178,7 +1178,7 @@ mod tests {
                 Err(BlockchainError::InvalidResponse),
                 &logger
             ),
-            BlockMarker::Value(150)
+            BlockMarker::Value(149)
         );
         assert_eq!(
             Subject::calculate_end_block_marker(
@@ -1196,7 +1196,7 @@ mod tests {
                 Ok(120.into()),
                 &logger
             ),
-            BlockMarker::Value(50 + 10)
+            BlockMarker::Value(59)
         );
     }
 

--- a/node/src/blockchain/blockchain_interface/blockchain_interface_web3/mod.rs
+++ b/node/src/blockchain/blockchain_interface/blockchain_interface_web3/mod.rs
@@ -367,7 +367,9 @@ impl BlockchainInterfaceWeb3 {
     ) -> BlockMarker {
         let locally_determined_end_block_marker = match (start_block_marker, scan_range) {
             (BlockMarker::Value(start_block), BlockScanRange::Range(scan_range_number)) => {
-                BlockMarker::Value(start_block + scan_range_number)
+                // Subtract 1 because the range is inclusive: [start_block, end_block]
+                // Example: If max range is 20000, we need start_block to start_block+20000-1 (ending up with 20000 blocks total)
+                BlockMarker::Value(start_block + scan_range_number - 1)
             }
             (_, _) => BlockMarker::Uninitialized,
         };


### PR DESCRIPTION
Updated regex to capture maximum block count from error messages more accurately - namely update to Nodies provider. Added a new test case for extracting this specific error response.

Closes #734 