### PR TITLE
Update ci-matrix to test new runners

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         target:
           - { name: linux, os: ubuntu-22.04 }
-          - { name: macos, os: macos-13 }
-          - { name: windows, os: windows-2022 }
+          - { name: macos, os: macos-latest }
+          - { name: windows, os: windows-latest }
 
     name: Build node on ${{ matrix.target.os }}
     runs-on: ${{ matrix.target.os }}

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -15,7 +15,7 @@ jobs:
         target:
           - { name: linux, os: ubuntu-22.04 }
           - { name: macos, os: macos-latest }
-          - { name: windows, os: windows-latest }
+          - { name: windows, os: windows-2022 }
 
     name: Build node on ${{ matrix.target.os }}
     runs-on: ${{ matrix.target.os }}


### PR DESCRIPTION
GH has deprecated macos-13 runner and enforced macos15
Switched to macos-latest which runs the macos-15 Arm (not intel only) runner

Also changed Windows to windows-latest runner, as we want to inspect if there are performance issues with windows-2022 runner, as there is noticeable performance differences on Windows 11 vs Windows 10 being reported