### PR TITLE
GH-686 Don't allow extreme rate packs; reject Gossip about extreme rate packs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/*.rs.bk
 .idea/azure/
 .idea/inspectionProfiles/Project_Default.xml
+.idea/copilot.*
 
 ### Node
 node_modules

--- a/.idea/SweepConfig.xml
+++ b/.idea/SweepConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="dev.sweep.assistant.components.SweepConfig">
+    <option name="autoApprovedTools">
+      <set>
+        <option value="list_files" />
+        <option value="read_file" />
+        <option value="search_files" />
+        <option value="find_usages" />
+        <option value="get_errors" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/SweepConfig.xml
+++ b/.idea/SweepConfig.xml
@@ -10,5 +10,58 @@
         <option value="get_errors" />
       </set>
     </option>
+    <option name="byokProviderConfigs">
+      <map>
+        <entry key="anthropic">
+          <value>
+            <BYOKProviderConfig>
+              <option name="eligibleModels">
+                <list>
+                  <option value="claude-sonnet-4-5-20250929" />
+                  <option value="claude-opus-4-5-20251101" />
+                  <option value="claude-haiku-4-5" />
+                </list>
+              </option>
+            </BYOKProviderConfig>
+          </value>
+        </entry>
+        <entry key="grok">
+          <value>
+            <BYOKProviderConfig>
+              <option name="eligibleModels">
+                <list>
+                  <option value="grok-code-fast-1" />
+                </list>
+              </option>
+            </BYOKProviderConfig>
+          </value>
+        </entry>
+        <entry key="openai">
+          <value>
+            <BYOKProviderConfig>
+              <option name="eligibleModels">
+                <list>
+                  <option value="gpt-5-2025-08-07" />
+                  <option value="gpt-5-codex" />
+                  <option value="gpt-5.1-2025-11-13" />
+                  <option value="gpt-5.2-2025-12-11" />
+                </list>
+              </option>
+            </BYOKProviderConfig>
+          </value>
+        </entry>
+        <entry key="z-ai">
+          <value>
+            <BYOKProviderConfig>
+              <option name="eligibleModels">
+                <list>
+                  <option value="z-ai/glm-4.7" />
+                </list>
+              </option>
+            </BYOKProviderConfig>
+          </value>
+        </entry>
+      </map>
+    </option>
   </component>
 </project>

--- a/SWEEP.md
+++ b/SWEEP.md
@@ -1,0 +1,549 @@
+# SWEEP.md - MASQ Node Development Guide
+
+This file contains essential information for AI assistants and developers working on the MASQ Node project, including coding standards, common commands, project structure, and development workflows.
+
+## Table of Contents
+- [Project Overview](#project-overview)
+- [Common Terminal Commands](#common-terminal-commands)
+- [Project Structure](#project-structure)
+- [Development Workflow](#development-workflow)
+- [Code Style and Standards](#code-style-and-standards)
+- [Testing Guidelines](#testing-guidelines)
+- [Build and CI/CD](#build-and-cicd)
+- [Important Notes](#important-notes)
+
+---
+
+## Project Overview
+
+**MASQ Node** is the foundation of the MASQ Network, an open-source decentralized mesh-network (dMN) written primarily in Rust. It combines the benefits of VPN and Tor technology to create next-generation privacy software.
+
+### Key Technologies
+- **Language**: Rust (2021 edition)
+- **Build System**: Cargo
+- **Testing**: Unit tests, integration tests, multinode integration tests (Docker-based)
+- **CI/CD**: GitHub Actions
+- **Platforms**: Linux, macOS, Windows (64-bit)
+
+### Repository Structure
+The project is organized as a Cargo workspace with multiple crates:
+- `node/` - Main MASQ Node implementation
+- `masq/` - Command-line user interface
+- `masq_lib/` - Shared library code
+- `dns_utility/` - DNS configuration utility - deprecated
+- `automap/` - Automatic public-IP detection and configuration
+- `port_exposer/` - Port exposure utilities for testing only
+- `ip_country/` - IP geolocation functionality
+- `multinode_integration_tests/` - Docker-based integration tests employing multiple simultaneous Nodes
+
+---
+
+## Common Terminal Commands
+
+### Building and Testing
+
+#### Run All Tests and Checks (Full CI Pipeline)
+```bash
+ci/all.sh
+```
+This runs formatting, linting, unit tests, and integration tests for all components. **You will be prompted for your password** during zero-hop integration tests (requires sudo).
+
+#### Run Multinode Integration Tests (Linux only)
+```bash
+ci/multinode_integration_test.sh
+```
+Note: These tests only run on Linux and require Docker.
+
+#### Format Code
+```bash
+ci/format.sh
+```
+Formats all Rust code using `rustfmt`. This is required before submitting PRs.
+
+#### Run Linting (Clippy)
+```bash
+cargo clippy -- -D warnings -Anon-snake-case
+```
+Or for a specific component:
+```bash
+cd node && ci/lint.sh
+```
+
+#### Run Unit Tests
+```bash
+# For the node component
+cd node && ci/unit_tests.sh
+
+# Or manually
+cargo test --release --lib --no-fail-fast --features masq_lib/log_recipient_test -- --nocapture --skip _integration
+```
+
+#### Run Integration Tests
+```bash
+cd node && ci/integration_tests.sh
+```
+Note: Integration tests require sudo privileges on Linux and macOS.
+
+#### Build Release Version
+```bash
+cargo build --release
+```
+
+#### Build Debug Version
+```bash
+cargo build
+```
+
+### Version Management
+
+#### Bump Version
+```bash
+cd ci && ./bump_version.sh <version>
+```
+Example:
+```bash
+cd ci && ./bump_version.sh 6.9.1
+```
+This updates version numbers in all `Cargo.toml` files and corresponding `Cargo.lock` files.
+
+### Running MASQ Node
+
+#### Start MASQ Daemon (Linux/macOS)
+```bash
+sudo nohup ./MASQNode --initialization &
+```
+
+#### Start MASQ Daemon (Windows)
+```bash
+start /b MASQNode --initialization
+```
+
+#### Start MASQ CLI
+```bash
+./masq
+```
+
+#### Run MASQ Command (Non-interactive)
+```bash
+./masq setup --log-level debug --clandestine-port 1234
+```
+
+#### Shutdown MASQ Node
+```bash
+./masq shutdown
+```
+
+#### Revert DNS Configuration
+```bash
+sudo ./dns_utility revert
+```
+
+### Git Workflow
+
+#### Update Master Branch
+```bash
+git checkout master
+git pull
+```
+
+#### Create Feature Branch
+```bash
+git checkout -b GH-<issue-number>
+git push -u origin HEAD
+```
+
+#### Merge Master into Feature Branch
+```bash
+git checkout master
+git pull
+git checkout -  # Returns to previous branch
+git merge master
+```
+
+### Docker Commands (for Multinode Tests)
+
+#### View Docker Logs
+```bash
+multinode_integration_tests/docker_logs.sh
+```
+
+#### Dump Docker State
+```bash
+multinode_integration_tests/docker_dump.sh
+```
+
+#### Build Docker Images
+```bash
+multinode_integration_tests/docker/build.sh
+```
+
+---
+
+## Project Structure
+
+### Main Components
+
+#### Node (`node/`)
+The core MASQ Node implementation containing:
+- `src/accountant/` - Payment and accounting logic
+- `src/blockchain/` - Blockchain interaction
+- `src/entry_dns/` - Tiny DNS server that returns 'localhost' for any hostname - deprecated
+- `src/hopper/` - Message routing
+- `src/neighborhood/` - Network topology management
+- `src/proxy_client/` - Exit-Node proxy
+- `src/proxy_server/` - Originating-Node proxy
+- `src/ui_gateway/` - User interface communication
+- `src/sub_lib/` - Code shared among accountant, blockchain, hopper, etc.
+- `src/test_utils/` - Testing utilities
+
+Each component has its own README.md with detailed documentation.
+
+#### MASQ CLI (`masq/`)
+Command-line interface for controlling the MASQ Daemon and Node.
+
+#### DNS Utility (`dns_utility/`) - deprecated
+The standard way to add intercept processing to your network data flow is to configure your system network stack to
+use an HTTP and/or HTTPS proxy. However, early in the history of Substratum, Justin Tabb made a promise that Node
+would be "zero-configuration." This utility, and the code in Node that it supports, were intended to keep that promise.
+Essentially, Node contains a tiny DNS server that always returns 'localhost' for any hostname; therefore, when your
+browser or other application performs DNS resolution, it will be fooled into routing its traffic through Node, which
+is running on `localhost`. This utility wrangles your system DNS settings to point at that tiny DNS server, if you're
+going to run Node, or back at your real DNS server if you're not. Since Node is now part of MASQ and no longer part of
+Substratum and Justin Tabb is a part of history, the Node now operates as an HTTPS proxy and its `entry_dns` server is
+no longer used. However, the code is still available and active and usable, so this utility remains available as well,
+although its use is deprecated.
+
+#### Multinode Integration Tests (`multinode_integration_tests/`)
+Docker-based integration tests that simulate multi-node networks.
+
+### Configuration Files
+
+#### Cargo.toml
+Each component has its own `Cargo.toml` defining dependencies and metadata.
+
+#### config.toml
+Runtime configuration file (located in data directory by default).
+- Can be specified via `--config-file` parameter or `MASQ_CONFIG_FILE` environment variable
+- Uses TOML format with scalar settings
+- Example: `clandestine-port = 1234`
+
+---
+
+## Development Workflow
+
+### Setting Up Development Environment
+
+1. **Install Rust toolchain**:
+   ```bash
+   rustup component add rustfmt
+   rustup component add clippy
+   ```
+
+2. **Install Docker** (for multinode tests on Linux)
+
+3. **Clone repository and test**:
+   ```bash
+   git clone <repository-url>
+   cd Node
+   ci/all.sh
+   ```
+
+### Working on an Issue
+
+1. **Select issue** from the [MASQ Node Card Wall](https://github.com/orgs/MASQ-Project/projects/1)
+2. **Update master branch**: `git checkout master && git pull`
+3. **Create feature branch**: `git checkout -b GH-<issue-number>`
+4. **Complete the work** (test-driven development required)
+5. **Merge in master regularly**: `git merge master`
+6. **Run full test suite**: `ci/all.sh`
+7. **Run multinode tests** (Linux only): `ci/multinode_integration_test.sh`
+8. **Push changes**: `git push`
+9. **Open pull request** on GitHub
+10. **Watch GitHub Actions build**
+11. **Address reviewer comments**
+12. **Wait for QA approval**
+
+### Commit Guidelines
+
+- Commit frequently (commits will be squashed before merging)
+- Commit when tests go green
+- Commit before trying risky changes
+- Write descriptive commit messages for your own reference
+
+---
+
+## Code Style and Standards
+
+### Rust Standards
+
+#### Formatting
+- Use `rustfmt` for all code formatting
+- Run `ci/format.sh` before committing (non-auto-formatted code will fail CI)
+- To skip formatting on specific code: `#[cfg_attr(rustfmt, rustfmt_skip)]`
+
+#### Linting
+- All code must pass `clippy` with `-D warnings`
+- Non-snake-case warnings are allowed: `-Anon-snake-case`
+- Run `cargo clippy -- -D warnings -Anon-snake-case`
+
+#### Compiler Flags
+```bash
+export RUSTFLAGS="-D warnings -Anon-snake-case"
+```
+
+#### Error Handling
+- Use `Result` types for fallible operations
+- Provide descriptive error messages
+- Handle errors appropriately (no `unwrap()` in production code; use `expect()` only, and that sparingly)
+- **Important:** Nothing that comes into the system from the network must ever be allowed to cause a panic. All the
+standard anti-injection rules apply, but whenever something from the outside generates an error, the error must be
+logged and execution must continue. (Sometimes additional action is appropriate, such as banning an evil Node; but
+logging the error is the bare minimum.) `eprintln!()` is not logging.
+
+#### Testing
+- **Test-Driven Development (TDD) is required**
+- All new code must have corresponding tests
+- Tests must pass before code review
+- Use descriptive test names
+- Test both success and failure cases
+
+### Naming Conventions
+- Use snake_case for functions and variables
+- Use PascalCase for types and traits
+- Use SCREAMING_SNAKE_CASE for constants
+- All zero-hop integration tests must have names _suffixed_ with `_integration`; otherwise they'll run as unit tests
+rather than integration tests.
+
+### Documentation
+- Document public APIs with doc comments (`///`)
+- Include examples in doc comments where helpful
+- Keep README.md files updated for each component
+
+---
+
+## Testing Guidelines
+
+### Test Types
+
+#### Unit Tests
+- Located in the same file as the code being tested (in `#[cfg(test)]` modules)
+- Test individual functions and methods in isolation
+- Run with: `cargo test --lib`
+- Should not require sudo or network access
+
+#### Integration Tests
+- Test interactions between components
+- Starts up a real Node, always in `--neighborhood-mode zero-hop`
+- Will require sudo privileges, because a Node has to start with root privileges to open low ports
+- Run with: `ci/integration_tests.sh`
+
+#### Multinode Integration Tests
+- Docker-based tests simulating multi-node networks
+- **Linux only** (do not run on macOS or Windows)
+- Require Docker installation
+- Run with: `ci/multinode_integration_test.sh`
+
+### Test Execution
+
+#### Run All Tests
+```bash
+ci/all.sh
+```
+
+#### Run Specific Test
+```bash
+cargo test test_name -- --nocapture
+```
+
+#### Run Tests with Backtrace
+```bash
+RUST_BACKTRACE=full cargo test
+```
+
+#### Run Tests in Release Mode
+```bash
+cargo test --release
+```
+
+### Test Features
+- Use `--no-fail-fast` to run all tests even if some fail
+- Use `--nocapture` to see println! output
+
+---
+
+## Build and CI/CD
+
+### Local Build Process
+
+The `ci/all.sh` script performs the following:
+1. Format check and auto-format (`ci/format.sh`)
+2. Install git hooks (`install-hooks.sh`)
+3. Start sccache server (for faster compilation)
+4. Build and test each component:
+   - masq_lib
+   - node
+   - dns_utility
+   - masq (CLI)
+   - automap
+   - ip_country
+
+### GitHub Actions
+
+- Builds run automatically on pull requests
+- Unit and single-Node integration tests run on Linux, macOS, and Windows
+- Multinode integration tests run on Linux only
+- All builds must pass before merging
+
+### Build Artifacts
+
+After successful builds, artifacts are available in:
+- `/target/release/` and `/target/debug/` - Executable binaries
+  - `MASQNode` (or `MASQNode.exe`) - Node and Daemon
+  - `masq` - Command-line interface
+  - `dns_utility` - DNS configuration tool
+  - `automap` - Firewall penetration test utility: requires special remote setup
+
+### Caching
+
+The project uses `sccache` for faster compilation:
+```bash
+export SCCACHE_DIR="$HOME/.cargo/sccache"
+SCCACHE_IDLE_TIMEOUT=0 sccache --start-server
+```
+
+---
+
+## Important Notes
+
+### Platform-Specific Considerations
+
+#### Linux
+- Full support for all features
+- Multinode integration tests available
+- Requires sudo for integration tests
+- May need to free port 53: `sudo ci/free-port-53.sh`
+
+#### macOS
+- Full support except multinode integration tests
+- Requires sudo for integration tests
+- May need to adjust file descriptor limits in GitHub Actions
+
+#### Windows
+- Use Git Bash for running scripts
+- Multinode integration tests not supported
+- Some services may need to be stopped (ICS, W3SVC)
+- 32-bit Windows not reliably supported (use 64-bit)
+- Run as Administrator
+
+### Security Considerations
+
+- **MASQ Node is currently in beta** - not clandestine yet
+- Do not use for sensitive traffic
+- Traffic cannot be decrypted by attackers but MASQ traffic is identifiable
+- Database encryption uses a user-provided password
+- Password is never stored on disk
+- Forgetting the password means losing all the encrypted content in the database and starting over
+
+### Configuration Priority
+
+Configuration sources in order of priority (highest to lowest):
+1. `masq` UI commands
+2. Environment variables (prefixed with `MASQ_`)
+3. Configuration file (`config.toml`)
+4. Defaults
+
+Example:
+- CLI, non-interactive mode: `masq setup --clandestine-port 1234`
+- Environment: `MASQ_CLANDESTINE_PORT=1234`
+- Config file: `clandestine-port = "1234"`
+
+### Daemon vs Node
+
+- **Daemon**: Runs with admin privileges, starts at boot, cannot access network or communicate with Node
+- **Node**: Starts with admin privileges, drops privileges after network configuration, handles all network traffic
+- UI connects to Daemon first, then is redirected to Node when it first sends the Daemon a Node command
+
+### Error Handling in Browser
+
+#### HTTP Errors
+- MASQ Node can impersonate the remote server for HTTP errors
+- Errors are clearly marked as coming from MASQ Node rather than the remote server
+
+#### TLS Errors
+- In-band error reporting severely limited by TLS protocol; only available for ClientHello
+- Friendliest errors are written to the log
+
+### Development Tools
+
+#### Recommended IDE
+- JetBrains IntelliJ IDEA with Rust plugin (used by MASQ team)
+- Other options: VS Code with rust-analyzer, etc.
+
+#### Required Tools
+- Rust toolchain (rustc, cargo, rustfmt, clippy)
+- Git
+- Docker (for multinode tests on Linux)
+- sudo access (for integration tests)
+
+### Useful Links
+
+- [MASQ Node Repository](https://github.com/MASQ-Project/Node)
+- [MASQ Node Card Wall](https://github.com/orgs/MASQ-Project/projects/1)
+- [GitHub Actions Build Site](https://github.com/MASQ-Project/Node/actions)
+- [Knowledge Base](https://docs.masq.ai/masq)
+- [Discord Channel](https://discord.gg/masq)
+- [Latest Release](https://github.com/MASQ-Project/Node/releases/latest)
+
+---
+
+## Quick Reference
+
+### Most Common Commands
+
+```bash
+# Full test suite
+ci/all.sh
+
+# Format code
+ci/format.sh
+
+# Lint code
+cargo clippy -- -D warnings -Anon-snake-case
+
+# Run unit tests
+cargo test --release --lib --no-fail-fast
+
+# Build release
+cargo build --release
+
+# Start daemon (Linux/macOS)
+sudo nohup ./MASQNode --initialization &
+
+# Start CLI
+./masq
+
+# Shutdown node
+./masq shutdown
+```
+
+### Environment Variables
+
+```bash
+export RUST_BACKTRACE=full          # Full backtraces on panic
+export RUSTFLAGS="-D warnings -Anon-snake-case"  # Compiler flags
+export SCCACHE_DIR="$HOME/.cargo/sccache"  # Cache directory
+```
+
+### File Locations
+
+- Binaries: `/target/release/` or `/target/debug/`
+- Config file: `<data-directory>/config.toml`
+- Database: `<data-directory>/`
+- Logs: Configured via `--log-level` parameter
+
+---
+
+**Last Updated**: 2026
+**Project**: MASQ Node
+**License**: GPL-3.0-only
+**Copyright**: (c) 2026, MASQ Network

--- a/masq_lib/src/constants.rs
+++ b/masq_lib/src/constants.rs
@@ -5,7 +5,7 @@ use crate::data_version::DataVersion;
 use const_format::concatcp;
 
 pub const DEFAULT_CHAIN: Chain = Chain::BaseMainnet;
-pub const CURRENT_SCHEMA_VERSION: usize = 11;
+pub const CURRENT_SCHEMA_VERSION: usize = 12;
 
 pub const HIGHEST_RANDOM_CLANDESTINE_PORT: u16 = 9999;
 pub const HTTP_PORT: u16 = 80;

--- a/multinode_integration_tests/src/masq_node_cluster.rs
+++ b/multinode_integration_tests/src/masq_node_cluster.rs
@@ -308,6 +308,15 @@ impl MASQNodeCluster {
     fn create_network() -> Result<(), String> {
         let mut command = Command::new(
             "docker",
+            Command::strings(vec!["network", "rm", "integration_net"]),
+        );
+        match command.stdout_or_stderr() {
+            Ok(_) => println!("Removed existing integration_net network"),
+            Err(msg) if msg.contains("network integration_net not found") => println!("No existing integration_net network to remove: cool!"),
+            Err(msg) => return Err(format!("Error removing existing integration_net network: {}", msg)),
+        }
+        let mut command = Command::new(
+            "docker",
             Command::strings(vec![
                 "network",
                 "create",

--- a/multinode_integration_tests/src/masq_node_cluster.rs
+++ b/multinode_integration_tests/src/masq_node_cluster.rs
@@ -312,8 +312,15 @@ impl MASQNodeCluster {
         );
         match command.stdout_or_stderr() {
             Ok(_) => println!("Removed existing integration_net network"),
-            Err(msg) if msg.contains("network integration_net not found") => println!("No existing integration_net network to remove: cool!"),
-            Err(msg) => return Err(format!("Error removing existing integration_net network: {}", msg)),
+            Err(msg) if msg.contains("network integration_net not found") => {
+                println!("No existing integration_net network to remove: cool!")
+            }
+            Err(msg) => {
+                return Err(format!(
+                    "Error removing existing integration_net network: {}",
+                    msg
+                ))
+            }
         }
         let mut command = Command::new(
             "docker",

--- a/multinode_integration_tests/src/masq_node_cluster.rs
+++ b/multinode_integration_tests/src/masq_node_cluster.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::env;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, ToSocketAddrs};
+use std::time::Duration;
 
 pub struct MASQNodeCluster {
     startup_configs: HashMap<(String, usize), NodeStartupConfig>,
@@ -306,6 +307,23 @@ impl MASQNodeCluster {
     }
 
     fn create_network() -> Result<(), String> {
+        let mut errors = vec![];
+        let mut retries_remaining = 2;
+        let interval = Duration::from_millis(250);
+        while retries_remaining >= 0 {
+            match MASQNodeCluster::create_network_attempt() {
+                Ok(s) => return Ok(s),
+                Err(err_msg) => {
+                    retries_remaining -= 1;
+                    errors.push(err_msg);
+                    std::thread::sleep(interval);
+                }
+            }
+        }
+        Err(format!("Errors trying to create Docker network:\n  {}\n", errors.join("\n  ")))
+    }
+
+    fn create_network_attempt() -> Result<(), String> {
         let mut command = Command::new(
             "docker",
             Command::strings(vec!["network", "rm", "integration_net"]),

--- a/multinode_integration_tests/src/masq_node_cluster.rs
+++ b/multinode_integration_tests/src/masq_node_cluster.rs
@@ -320,7 +320,10 @@ impl MASQNodeCluster {
                 }
             }
         }
-        Err(format!("Errors trying to create Docker network:\n  {}\n", errors.join("\n  ")))
+        Err(format!(
+            "Errors trying to create Docker network:\n  {}\n",
+            errors.join("\n  ")
+        ))
     }
 
     fn create_network_attempt() -> Result<(), String> {

--- a/multinode_integration_tests/tests/bookkeeping_test.rs
+++ b/multinode_integration_tests/tests/bookkeeping_test.rs
@@ -14,6 +14,7 @@ use node_lib::sub_lib::wallet::Wallet;
 use std::collections::HashMap;
 use std::thread;
 use std::time::{Duration, SystemTime};
+use itertools::Itertools;
 
 #[test]
 fn provided_and_consumed_services_are_recorded_in_databases() {
@@ -30,54 +31,63 @@ fn provided_and_consumed_services_are_recorded_in_databases() {
 
     let mut client = originating_node.make_client(8080, STANDARD_CLIENT_TIMEOUT_MILLIS);
     client.set_timeout(Duration::from_secs(10));
-    let request = "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n".as_bytes();
+    let request = "GET /index.html HTTP/1.1\r\nHost: www.testingmcafeesites.com\r\n\r\n".as_bytes();
 
     client.send_chunk(request);
     let response = String::from_utf8(client.wait_for_chunk()).unwrap();
     assert!(
-        response.contains("<h1>Example Domain</h1>"),
-        "Not from www.example.com:\n{}",
+        response.contains("<title>URL for testing.</title>"),
+        "Not from www.testingmcafeesites.com:\n{}",
         response
     );
+
+    // Waiting until everybody has finished generating payables and receivables
+    thread::sleep(Duration::from_secs(10));
 
     // get all payables from originating node
     let payables = non_pending_payables(&originating_node);
 
-    // Waiting until the serving nodes have finished accruing their receivables
-    thread::sleep(Duration::from_secs(10));
-
     // get all receivables from all other nodes
-    let receivable_balances = non_originating_nodes
+    let receivable_nodes = non_originating_nodes
         .iter()
         .flat_map(|node| {
             receivables(node)
                 .into_iter()
                 .map(move |receivable_account| {
-                    (node.earning_wallet(), receivable_account.balance_wei)
+                    (node.earning_wallet(), (node.name().to_string(), receivable_account.balance_wei))
                 })
         })
-        .collect::<HashMap<Wallet, i128>>();
+        .collect::<HashMap<Wallet, (String, i128)>>();
 
     // check that each payable has a receivable
     assert_eq!(
         payables.len(),
-        receivable_balances.len(),
+        receivable_nodes.len(),
         "Lengths of payables and receivables should match.\nPayables: {:?}\nReceivables: {:?}",
         payables,
-        receivable_balances
+        receivable_nodes
     );
     assert!(
-        receivable_balances.len() >= 3, // minimum service list: route, route, exit.
+        receivable_nodes.len() >= 3, // minimum service list: route, route, exit.
         "not enough receivables found {:?}",
-        receivable_balances
+        receivable_nodes
     );
 
-    payables.iter().for_each(|payable| {
-        assert_eq!(
-            payable.balance_wei,
-            *receivable_balances.get(&payable.wallet).unwrap() as u128,
-        );
-    });
+    let messages = payables.iter().flat_map(|payable| {
+        let payable_balance = payable.balance_wei;
+        let (non_originating_node_name, receivable_balance) = receivable_nodes.get(&payable.wallet).unwrap().clone();
+        if payable_balance != receivable_balance as u128 {
+            Some(format!(
+                "Payable for {} ({}) does not match receivable for {} ({})",
+                originating_node.name(), payable_balance, non_originating_node_name, receivable_balance
+            ))
+        } else {
+            None
+        }
+    })
+        .collect_vec();
+
+    assert!(messages.is_empty(), "{:#?}", messages);
 }
 
 fn non_pending_payables(node: &MASQRealNode) -> Vec<PayableAccount> {

--- a/multinode_integration_tests/tests/bookkeeping_test.rs
+++ b/multinode_integration_tests/tests/bookkeeping_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2019, MASQ (https://masq.ai) and/or its affiliates. All rights reserved.
+use itertools::Itertools;
 use multinode_integration_tests_lib::masq_node::{MASQNode, NodeReference};
 use multinode_integration_tests_lib::masq_node_cluster::MASQNodeCluster;
 use multinode_integration_tests_lib::masq_real_node::{
@@ -14,7 +15,6 @@ use node_lib::sub_lib::wallet::Wallet;
 use std::collections::HashMap;
 use std::thread;
 use std::time::{Duration, SystemTime};
-use itertools::Itertools;
 
 #[test]
 fn provided_and_consumed_services_are_recorded_in_databases() {
@@ -54,7 +54,10 @@ fn provided_and_consumed_services_are_recorded_in_databases() {
             receivables(node)
                 .into_iter()
                 .map(move |receivable_account| {
-                    (node.earning_wallet(), (node.name().to_string(), receivable_account.balance_wei))
+                    (
+                        node.earning_wallet(),
+                        (node.name().to_string(), receivable_account.balance_wei),
+                    )
                 })
         })
         .collect::<HashMap<Wallet, (String, i128)>>();
@@ -73,18 +76,24 @@ fn provided_and_consumed_services_are_recorded_in_databases() {
         receivable_nodes
     );
 
-    let messages = payables.iter().flat_map(|payable| {
-        let payable_balance = payable.balance_wei;
-        let (non_originating_node_name, receivable_balance) = receivable_nodes.get(&payable.wallet).unwrap().clone();
-        if payable_balance != receivable_balance as u128 {
-            Some(format!(
-                "Payable for {} ({}) does not match receivable for {} ({})",
-                originating_node.name(), payable_balance, non_originating_node_name, receivable_balance
-            ))
-        } else {
-            None
-        }
-    })
+    let messages = payables
+        .iter()
+        .flat_map(|payable| {
+            let payable_balance = payable.balance_wei;
+            let (non_originating_node_name, receivable_balance) =
+                receivable_nodes.get(&payable.wallet).unwrap().clone();
+            if payable_balance != receivable_balance as u128 {
+                Some(format!(
+                    "Payable for {} ({}) does not match receivable for {} ({})",
+                    originating_node.name(),
+                    payable_balance,
+                    non_originating_node_name,
+                    receivable_balance
+                ))
+            } else {
+                None
+            }
+        })
         .collect_vec();
 
     assert!(messages.is_empty(), "{:#?}", messages);

--- a/multinode_integration_tests/tests/communication_failure_test.rs
+++ b/multinode_integration_tests/tests/communication_failure_test.rs
@@ -241,7 +241,7 @@ fn dns_resolution_failure_with_real_nodes() {
             .chain(cluster.chain)
             .build(),
     );
-    let nodes = (0..5)
+    let nodes = (0..6)
         .map(|_| {
             cluster.start_real_node(
                 NodeStartupConfigBuilder::standard()

--- a/multinode_integration_tests/tests/connection_progress_test.rs
+++ b/multinode_integration_tests/tests/connection_progress_test.rs
@@ -44,7 +44,7 @@ fn connection_progress_is_properly_broadcast() {
     let ui_client = subject.make_ui(ui_port);
 
     // Hook up enough new Nodes to make the subject fully connected
-    let _additional_nodes = (0..3)
+    let _additional_nodes = (0..4)
         .into_iter()
         .map(|i| {
             cluster.start_real_node(
@@ -57,7 +57,7 @@ fn connection_progress_is_properly_broadcast() {
         .collect::<Vec<MASQRealNode>>();
 
     let message_body =
-        ui_client.wait_for_specific_broadcast(vec!["connectionChange"], Duration::from_secs(5));
+        ui_client.wait_for_specific_broadcast(vec!["connectionChange"], Duration::from_secs(10));
     let (ccb, _) = UiConnectionChangeBroadcast::fmb(message_body).unwrap();
     if ccb.stage == UiConnectionStage::ConnectedToNeighbor {
         let message_body =

--- a/multinode_integration_tests/tests/data_routing_test.rs
+++ b/multinode_integration_tests/tests/data_routing_test.rs
@@ -89,7 +89,7 @@ fn http_end_to_end_routing_test_with_consume_and_originate_only_nodes() {
             .chain(cluster.chain)
             .build(),
     );
-    let _potential_exit_nodes = vec![0, 1, 2, 3, 4]
+    let _potential_exit_nodes = vec![3, 4, 5, 6, 7]
         .into_iter()
         .map(|_| {
             cluster.start_real_node(
@@ -101,17 +101,19 @@ fn http_end_to_end_routing_test_with_consume_and_originate_only_nodes() {
         })
         .collect_vec();
 
-    thread::sleep(Duration::from_millis(1000));
+    thread::sleep(Duration::from_secs(5));
 
     let mut client = originating_node.make_client(8080, STANDARD_CLIENT_TIMEOUT_MILLIS);
-    client.send_chunk(b"GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n");
-    let response = client.wait_for_chunk();
+    client.set_timeout(Duration::from_secs(10));
+    let request = "GET /index.html HTTP/1.1\r\nHost: www.testingmcafeesites.com\r\n\r\n".as_bytes();
 
-    assert_eq!(
-        index_of(&response, &b"<h1>Example Domain</h1>"[..]).is_some(),
-        true,
-        "Actual response:\n{}",
-        String::from_utf8(response).unwrap()
+    client.send_chunk(request);
+    let response = String::from_utf8(client.wait_for_chunk()).unwrap();
+
+    assert!(
+        response.contains("<title>URL for testing.</title>"),
+        "Not from www.testingmcafeesites.com:\n{}",
+        response
     );
 }
 

--- a/multinode_integration_tests/tests/min_hops_tests.rs
+++ b/multinode_integration_tests/tests/min_hops_tests.rs
@@ -10,13 +10,14 @@ use multinode_integration_tests_lib::masq_real_node::{
 use node_lib::sub_lib::neighborhood::Hops;
 use std::thread;
 use std::time::Duration;
+use multinode_integration_tests_lib::neighborhood_constructor::construct_neighborhood;
 
 #[test]
 fn data_can_be_routed_using_different_min_hops() {
     // This test fails sometimes due to a timeout: "Couldn't read chunk: Kind(TimedOut)"
     // You may fix it by increasing the timeout for the client.
-    assert_http_end_to_end_routing(Hops::OneHop);
-    assert_http_end_to_end_routing(Hops::TwoHops);
+    // assert_http_end_to_end_routing(Hops::OneHop);
+    // assert_http_end_to_end_routing(Hops::TwoHops);
     assert_http_end_to_end_routing(Hops::SixHops);
 }
 
@@ -30,7 +31,7 @@ fn assert_http_end_to_end_routing(min_hops: Hops) {
     let first_node = cluster.start_real_node(config);
 
     // For 1-hop route, 3 nodes are necessary if we use last node as the originating node
-    let nodes_count = (min_hops as usize) + 2;
+    let nodes_count = (min_hops as usize) * 2 + 5;
     let nodes = (0..nodes_count)
         .map(|i| {
             cluster.start_real_node(
@@ -43,7 +44,7 @@ fn assert_http_end_to_end_routing(min_hops: Hops) {
         })
         .collect::<Vec<MASQRealNode>>();
 
-    thread::sleep(Duration::from_millis(500 * (nodes.len() as u64)));
+    thread::sleep(Duration::from_millis(4000 * (nodes.len() as u64)));
 
     let last_node = nodes.last().unwrap();
     let mut client = last_node.make_client(8080, 5000);

--- a/multinode_integration_tests/tests/min_hops_tests.rs
+++ b/multinode_integration_tests/tests/min_hops_tests.rs
@@ -10,7 +10,6 @@ use multinode_integration_tests_lib::masq_real_node::{
 use node_lib::sub_lib::neighborhood::Hops;
 use std::thread;
 use std::time::Duration;
-use multinode_integration_tests_lib::neighborhood_constructor::construct_neighborhood;
 
 #[test]
 fn data_can_be_routed_using_different_min_hops() {

--- a/multinode_integration_tests/tests/neighbor_selection_test.rs
+++ b/multinode_integration_tests/tests/neighbor_selection_test.rs
@@ -21,7 +21,7 @@ use std::convert::TryInto;
 use std::time::Duration;
 
 #[test]
-fn debut_target_does_not_introduce_known_neighbors() {
+fn debut_target_does_not_introduce_already_known_neighbors() {
     let mut cluster = MASQNodeCluster::start().unwrap();
     let one_common_neighbor = make_node_record(1234, true);
     let another_common_neighbor = make_node_record(2435, true);
@@ -76,8 +76,6 @@ fn debut_target_does_not_introduce_known_neighbors() {
         standard_gossip.key_set(),
         vec_to_set(vec![
             subject_real_node.main_public_key().clone(),
-            one_common_neighbor.public_key().clone(),
-            another_common_neighbor.public_key().clone(),
         ])
     );
 }

--- a/multinode_integration_tests/tests/neighbor_selection_test.rs
+++ b/multinode_integration_tests/tests/neighbor_selection_test.rs
@@ -74,9 +74,7 @@ fn debut_target_does_not_introduce_already_known_neighbors() {
     let standard_gossip = Standard::from(&agrs);
     assert_eq!(
         standard_gossip.key_set(),
-        vec_to_set(vec![
-            subject_real_node.main_public_key().clone(),
-        ])
+        vec_to_set(vec![subject_real_node.main_public_key().clone(),])
     );
 }
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -15,7 +15,7 @@ automap = { path = "../automap"}
 backtrace = "0.3.57"
 base64 = "0.13.0"
 bytes = "0.4.12"
-time = {version = "0.3.11", features = [ "macros" ]}
+time = { version = "0.3.11", features = ["macros", "local-offset"] }
 clap = "2.33.3"
 crossbeam-channel = "0.5.1"
 dirs = "4.0.0"

--- a/node/src/accountant/mod.rs
+++ b/node/src/accountant/mod.rs
@@ -610,14 +610,13 @@ impl Accountant {
         &mut self,
         msg: ReportRoutingServiceProvidedMessage,
     ) {
-        let total_charge = Self::total_charge(
-            msg.byte_rate,
-            msg.service_rate,
-            msg.payload_size,
-        );
+        let total_charge = Self::total_charge(msg.byte_rate, msg.service_rate, msg.payload_size);
         debug!(
             self.logger,
-            "Charging {} wei for routing of {} bytes to wallet {}", total_charge, msg.payload_size, msg.paying_wallet
+            "Charging {} wei for routing of {} bytes to wallet {}",
+            total_charge,
+            msg.payload_size,
+            msg.paying_wallet
         );
         self.record_service_provided(
             msg.service_rate,
@@ -633,11 +632,7 @@ impl Accountant {
         &mut self,
         msg: ReportExitServiceProvidedMessage,
     ) {
-        let total_charge = Self::total_charge(
-            msg.byte_rate,
-            msg.service_rate,
-            msg.payload_size,
-        );
+        let total_charge = Self::total_charge(msg.byte_rate, msg.service_rate, msg.payload_size);
         debug!(
             self.logger,
             "Charging {} wei for exit service for {} bytes to wallet {} at {} per service and {} per byte",
@@ -670,7 +665,7 @@ impl Accountant {
         let total_charge = Self::total_charge(
             msg.exit.byte_rate,
             msg.exit.service_rate,
-            msg.exit.payload_size
+            msg.exit.payload_size,
         );
         debug!(
             self.logger,
@@ -692,7 +687,7 @@ impl Accountant {
             let total_charge = Self::total_charge(
                 routing_service.byte_rate,
                 routing_service.service_rate,
-                msg.routing_payload_size
+                msg.routing_payload_size,
             );
             debug!(
                 self.logger,
@@ -3387,8 +3382,14 @@ mod tests {
             .receivable_daos(vec![ForAccountantBody(receivable_dao)])
             .build();
 
-        let _ = subject.record_service_provided(i64::MAX as u64, 1, 1000,
-            SystemTime::now(), 2, &wallet);
+        let _ = subject.record_service_provided(
+            i64::MAX as u64,
+            1,
+            1000,
+            SystemTime::now(),
+            2,
+            &wallet,
+        );
     }
 
     #[test]
@@ -3401,8 +3402,7 @@ mod tests {
             .receivable_daos(vec![ForAccountantBody(receivable_dao)])
             .build();
 
-        subject.record_service_provided(i64::MAX as u64, 1, 1000,
-            SystemTime::now(), 2, &wallet);
+        subject.record_service_provided(i64::MAX as u64, 1, 1000, SystemTime::now(), 2, &wallet);
 
         TestLogHandler::new().exists_log_containing(&format!(
             "ERROR: Accountant: Overflow error recording service provided for {}: service rate {}, byte rate 1, payload size 2. Skipping",
@@ -3422,7 +3422,14 @@ mod tests {
             .build();
         let service_rate = i64::MAX as u64;
 
-        subject.record_service_consumed(service_rate, 1, 9223372036854775809, SystemTime::now(), 2, &wallet);
+        subject.record_service_consumed(
+            service_rate,
+            1,
+            9223372036854775809,
+            SystemTime::now(),
+            2,
+            &wallet,
+        );
 
         TestLogHandler::new().exists_log_containing(&format!(
             "ERROR: Accountant: Overflow error recording consumed services from {}: total charge {}, service rate {}, byte rate 1, payload size 2. Skipping",
@@ -3447,7 +3454,14 @@ mod tests {
             .payable_daos(vec![ForAccountantBody(payable_dao)])
             .build();
 
-        let _ = subject.record_service_consumed(i64::MAX as u64, 1, 1000, SystemTime::now(), 2, &wallet);
+        let _ = subject.record_service_consumed(
+            i64::MAX as u64,
+            1,
+            1000,
+            SystemTime::now(),
+            2,
+            &wallet,
+        );
     }
 
     #[test]

--- a/node/src/accountant/mod.rs
+++ b/node/src/accountant/mod.rs
@@ -485,12 +485,11 @@ impl Accountant {
         &self,
         service_rate: u64,
         byte_rate: u64,
+        total_charge: u128,
         timestamp: SystemTime,
         payload_size: usize,
         wallet: &Wallet,
     ) {
-        let byte_charge = byte_rate as u128 * (payload_size as u128);
-        let total_charge = service_rate as u128 + byte_charge;
         if !self.our_wallet(wallet) {
             match self.receivable_dao
                 .as_ref()
@@ -519,12 +518,11 @@ impl Accountant {
         &self,
         service_rate: u64,
         byte_rate: u64,
+        total_charge: u128,
         timestamp: SystemTime,
         payload_size: usize,
         wallet: &Wallet,
     ) {
-        let byte_charge = byte_rate as u128 * (payload_size as u128);
-        let total_charge = service_rate as u128 + byte_charge;
         if !self.our_wallet(wallet) {
             match self.payable_dao
                 .as_ref()
@@ -612,13 +610,19 @@ impl Accountant {
         &mut self,
         msg: ReportRoutingServiceProvidedMessage,
     ) {
+        let total_charge = Self::total_charge(
+            msg.byte_rate,
+            msg.service_rate,
+            msg.payload_size,
+        );
         debug!(
             self.logger,
-            "Charging routing of {} bytes to wallet {}", msg.payload_size, msg.paying_wallet
+            "Charging {} wei for routing of {} bytes to wallet {}", total_charge, msg.payload_size, msg.paying_wallet
         );
         self.record_service_provided(
             msg.service_rate,
             msg.byte_rate,
+            total_charge,
             msg.timestamp,
             msg.payload_size,
             &msg.paying_wallet,
@@ -629,9 +633,15 @@ impl Accountant {
         &mut self,
         msg: ReportExitServiceProvidedMessage,
     ) {
+        let total_charge = Self::total_charge(
+            msg.byte_rate,
+            msg.service_rate,
+            msg.payload_size,
+        );
         debug!(
             self.logger,
-            "Charging exit service for {} bytes to wallet {} at {} per service and {} per byte",
+            "Charging {} wei for exit service for {} bytes to wallet {} at {} per service and {} per byte",
+            total_charge,
             msg.payload_size,
             msg.paying_wallet,
             msg.service_rate,
@@ -640,6 +650,7 @@ impl Accountant {
         self.record_service_provided(
             msg.service_rate,
             msg.byte_rate,
+            total_charge,
             msg.timestamp,
             msg.payload_size,
             &msg.paying_wallet,
@@ -656,31 +667,45 @@ impl Accountant {
 
     fn handle_report_services_consumed_message(&mut self, msg: ReportServicesConsumedMessage) {
         let msg_id = self.msg_id();
+        let total_charge = Self::total_charge(
+            msg.exit.byte_rate,
+            msg.exit.service_rate,
+            msg.exit.payload_size
+        );
         debug!(
             self.logger,
-            "MsgId {}: Accruing debt to {} for consuming {} exited bytes",
+            "MsgId {}: Accruing {} wei of debt to {} for consuming {} exited bytes",
             msg_id,
+            total_charge,
             msg.exit.earning_wallet,
             msg.exit.payload_size
         );
         self.record_service_consumed(
             msg.exit.service_rate,
             msg.exit.byte_rate,
+            total_charge,
             msg.timestamp,
             msg.exit.payload_size,
             &msg.exit.earning_wallet,
         );
         msg.routing.iter().for_each(|routing_service| {
+            let total_charge = Self::total_charge(
+                routing_service.byte_rate,
+                routing_service.service_rate,
+                msg.routing_payload_size
+            );
             debug!(
                 self.logger,
-                "MsgId {}: Accruing debt to {} for consuming {} routed bytes",
+                "MsgId {}: Accruing {} wei of debt to {} for consuming {} routed bytes",
                 msg_id,
+                total_charge,
                 routing_service.earning_wallet,
                 msg.routing_payload_size
             );
             self.record_service_consumed(
                 routing_service.service_rate,
                 routing_service.byte_rate,
+                total_charge,
                 msg.timestamp,
                 msg.routing_payload_size,
                 &routing_service.earning_wallet,
@@ -962,6 +987,11 @@ impl Accountant {
                 serialize_hashes(&msg.hashes_and_balances)
             ),
         }
+    }
+
+    fn total_charge(byte_rate: u64, service_rate: u64, payload_size: usize) -> u128 {
+        let byte_charge = byte_rate as u128 * (payload_size as u128);
+        service_rate as u128 + byte_charge
     }
 
     fn financial_statistics(&self) -> Ref<'_, FinancialStatistics> {
@@ -2846,7 +2876,7 @@ mod tests {
             (now, make_wallet("booga"), (1 * 42) + (1234 * 24))
         );
         TestLogHandler::new().exists_log_containing(&format!(
-            "DEBUG: Accountant: Charging routing of 1234 bytes to wallet {}",
+            "DEBUG: Accountant: Charging 29658 wei for routing of 1234 bytes to wallet {}",
             paying_wallet
         ));
     }
@@ -2983,7 +3013,7 @@ mod tests {
             (now, make_wallet("booga"), (1 * 42) + (1234 * 24))
         );
         TestLogHandler::new().exists_log_containing(&format!(
-            "DEBUG: Accountant: Charging exit service for 1234 bytes to wallet {}",
+            "DEBUG: Accountant: Charging 29658 wei for exit service for 1234 bytes to wallet {}",
             paying_wallet
         ));
     }
@@ -3155,15 +3185,15 @@ mod tests {
         let test_log_handler = TestLogHandler::new();
 
         test_log_handler.exists_log_containing(&format!(
-            "DEBUG: Accountant: MsgId 123: Accruing debt to {} for consuming 1200 exited bytes",
+            "DEBUG: Accountant: MsgId 123: Accruing 36120 wei of debt to {} for consuming 1200 exited bytes",
             earning_wallet_exit
         ));
         test_log_handler.exists_log_containing(&format!(
-            "DEBUG: Accountant: MsgId 123: Accruing debt to {} for consuming 3456 routed bytes",
+            "DEBUG: Accountant: MsgId 123: Accruing 82986 wei of debt to {} for consuming 3456 routed bytes",
             earning_wallet_routing_1
         ));
         test_log_handler.exists_log_containing(&format!(
-            "DEBUG: Accountant: MsgId 123: Accruing debt to {} for consuming 3456 routed bytes",
+            "DEBUG: Accountant: MsgId 123: Accruing 114100 wei of debt to {} for consuming 3456 routed bytes",
             earning_wallet_routing_2
         ));
     }
@@ -3357,7 +3387,8 @@ mod tests {
             .receivable_daos(vec![ForAccountantBody(receivable_dao)])
             .build();
 
-        let _ = subject.record_service_provided(i64::MAX as u64, 1, SystemTime::now(), 2, &wallet);
+        let _ = subject.record_service_provided(i64::MAX as u64, 1, 1000,
+            SystemTime::now(), 2, &wallet);
     }
 
     #[test]
@@ -3370,7 +3401,8 @@ mod tests {
             .receivable_daos(vec![ForAccountantBody(receivable_dao)])
             .build();
 
-        subject.record_service_provided(i64::MAX as u64, 1, SystemTime::now(), 2, &wallet);
+        subject.record_service_provided(i64::MAX as u64, 1, 1000,
+            SystemTime::now(), 2, &wallet);
 
         TestLogHandler::new().exists_log_containing(&format!(
             "ERROR: Accountant: Overflow error recording service provided for {}: service rate {}, byte rate 1, payload size 2. Skipping",
@@ -3390,7 +3422,7 @@ mod tests {
             .build();
         let service_rate = i64::MAX as u64;
 
-        subject.record_service_consumed(service_rate, 1, SystemTime::now(), 2, &wallet);
+        subject.record_service_consumed(service_rate, 1, 9223372036854775809, SystemTime::now(), 2, &wallet);
 
         TestLogHandler::new().exists_log_containing(&format!(
             "ERROR: Accountant: Overflow error recording consumed services from {}: total charge {}, service rate {}, byte rate 1, payload size 2. Skipping",
@@ -3415,7 +3447,7 @@ mod tests {
             .payable_daos(vec![ForAccountantBody(payable_dao)])
             .build();
 
-        let _ = subject.record_service_consumed(i64::MAX as u64, 1, SystemTime::now(), 2, &wallet);
+        let _ = subject.record_service_consumed(i64::MAX as u64, 1, 1000, SystemTime::now(), 2, &wallet);
     }
 
     #[test]

--- a/node/src/bootstrapper.rs
+++ b/node/src/bootstrapper.rs
@@ -748,7 +748,7 @@ mod tests {
     use tokio::prelude::Async;
 
     lazy_static! {
-        static ref CRYPTDE_PAIR: CryptDEPair = CryptDEPair::null();
+        static ref BS_CRYPTDE_PAIR: CryptDEPair = CryptDEPair::null();
         pub static ref INITIALIZATION: Mutex<bool> = Mutex::new(false);
     }
 
@@ -1534,13 +1534,13 @@ mod tests {
         );
         let cryptde_ref = {
             let descriptor = Bootstrapper::make_local_descriptor(
-                CRYPTDE_PAIR.main.as_ref(),
+                BS_CRYPTDE_PAIR.main.as_ref(),
                 Some(node_addr),
                 TEST_DEFAULT_CHAIN,
             );
-            Bootstrapper::report_local_descriptor(CRYPTDE_PAIR.main.as_ref(), &descriptor);
+            Bootstrapper::report_local_descriptor(BS_CRYPTDE_PAIR.main.as_ref(), &descriptor);
 
-            CRYPTDE_PAIR.main.as_ref()
+            BS_CRYPTDE_PAIR.main.as_ref()
         };
         let expected_descriptor = format!(
             "masq://base-sepolia:{}@2.3.4.5:3456/4567",
@@ -1576,13 +1576,13 @@ mod tests {
         init_test_logging();
         let cryptdes = {
             let descriptor = Bootstrapper::make_local_descriptor(
-                CRYPTDE_PAIR.main.as_ref(),
+                BS_CRYPTDE_PAIR.main.as_ref(),
                 None,
                 TEST_DEFAULT_CHAIN,
             );
-            Bootstrapper::report_local_descriptor(CRYPTDE_PAIR.main.as_ref(), &descriptor);
+            Bootstrapper::report_local_descriptor(BS_CRYPTDE_PAIR.main.as_ref(), &descriptor);
 
-            CRYPTDE_PAIR.clone()
+            BS_CRYPTDE_PAIR.clone()
         };
         let expected_descriptor = format!(
             "masq://base-sepolia:{}@:",

--- a/node/src/daemon/setup_reporter.rs
+++ b/node/src/daemon/setup_reporter.rs
@@ -1518,7 +1518,7 @@ mod tests {
             ("neighborhood-mode", "originate-only", Set),
             ("neighbors", "masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@1.2.3.4:1234,masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@5.6.7.8:5678", Set),
             ("payment-thresholds","1234|50000|1000|1000|20000|20000",Set),
-            ("rate-pack","1|3|3|8",Set),
+            ("rate-pack","100|300|300|800",Set),
             #[cfg(not(target_os = "windows"))]
             ("real-user", "9999:9999:booga", Set),
             ("scan-intervals","150|150|150",Set),
@@ -1548,7 +1548,7 @@ mod tests {
             ("neighborhood-mode", "originate-only", Set),
             ("neighbors", "masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@1.2.3.4:1234,masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@5.6.7.8:5678", Set),
             ("payment-thresholds","1234|50000|1000|1000|20000|20000",Set),
-            ("rate-pack","1|3|3|8",Set),
+            ("rate-pack","100|300|300|800",Set),
             #[cfg(not(target_os = "windows"))]
             ("real-user", "9999:9999:booga", Set),
             ("scan-intervals","150|150|150",Set),
@@ -1588,7 +1588,7 @@ mod tests {
             ("neighborhood-mode", "originate-only"),
             ("neighbors", "masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@1.2.3.4:1234,masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@5.6.7.8:5678"),
             ("payment-thresholds","1234|50000|1000|1000|15000|15000"),
-            ("rate-pack","1|3|3|8"),
+            ("rate-pack","100|300|300|800"),
             #[cfg(not(target_os = "windows"))]
             ("real-user", "9999:9999:booga"),
             ("scan-intervals","140|130|150"),
@@ -1623,7 +1623,7 @@ mod tests {
             ("neighborhood-mode", "originate-only", Set),
             ("neighbors", "masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@1.2.3.4:1234,masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@5.6.7.8:5678", Set),
             ("payment-thresholds","1234|50000|1000|1000|15000|15000",Set),
-            ("rate-pack","1|3|3|8",Set),
+            ("rate-pack","100|300|300|800",Set),
             #[cfg(not(target_os = "windows"))]
             ("real-user", "9999:9999:booga", Set),
             ("scan-intervals","140|130|150",Set),
@@ -1664,7 +1664,7 @@ mod tests {
             ("MASQ_NEIGHBORHOOD_MODE", "originate-only"),
             ("MASQ_NEIGHBORS", "masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@1.2.3.4:1234,masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@5.6.7.8:5678"),
             ("MASQ_PAYMENT_THRESHOLDS","12345|50000|1000|1234|19000|20000"),
-            ("MASQ_RATE_PACK","1|3|3|8"),
+            ("MASQ_RATE_PACK","100|300|300|800"),
             #[cfg(not(target_os = "windows"))]
             ("MASQ_REAL_USER", "9999:9999:booga"),
             ("MASQ_SCANS", "off"),
@@ -1696,7 +1696,7 @@ mod tests {
             ("neighborhood-mode", "originate-only", Configured),
             ("neighbors", "masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@1.2.3.4:1234,masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@5.6.7.8:5678", Configured),
             ("payment-thresholds","12345|50000|1000|1234|19000|20000",Configured),
-            ("rate-pack","1|3|3|8",Configured),
+            ("rate-pack","100|300|300|800",Configured),
             #[cfg(not(target_os = "windows"))]
             ("real-user", "9999:9999:booga", Configured),
             ("scan-intervals","133|133|111",Configured),
@@ -1756,7 +1756,9 @@ mod tests {
                 .write_all(b"neighborhood-mode = \"standard\"\n")
                 .unwrap();
             config_file.write_all(b"scans = \"off\"\n").unwrap();
-            config_file.write_all(b"rate-pack = \"2|2|2|2\"\n").unwrap();
+            config_file
+                .write_all(b"rate-pack = \"200|200|200|200\"\n")
+                .unwrap();
             config_file
                 .write_all(b"payment-thresholds = \"3333|55|33|646|999|999\"\n")
                 .unwrap();
@@ -1799,7 +1801,7 @@ mod tests {
                 .unwrap();
             config_file.write_all(b"scans = \"off\"\n").unwrap();
             config_file
-                .write_all(b"rate-pack = \"55|50|60|61\"\n")
+                .write_all(b"rate-pack = \"5500|5000|6000|6100\"\n")
                 .unwrap();
             config_file
                 .write_all(b"payment-thresholds = \"4000|1000|3000|3333|10000|20000\"\n")
@@ -1864,7 +1866,7 @@ mod tests {
                 "4000|1000|3000|3333|10000|20000",
                 Configured,
             ),
-            ("rate-pack", "55|50|60|61", Configured),
+            ("rate-pack", "5500|5000|6000|6100", Configured),
             #[cfg(not(target_os = "windows"))]
             (
                 "real-user",
@@ -1914,7 +1916,7 @@ mod tests {
             ("MASQ_NEIGHBORHOOD_MODE", "originate-only"),
             ("MASQ_NEIGHBORS", "masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@1.2.3.4:1234,masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@5.6.7.8:5678"),
             ("MASQ_PAYMENT_THRESHOLDS","1234|50000|1000|1000|20000|20000"),
-            ("MASQ_RATE_PACK","1|3|3|8"),
+            ("MASQ_RATE_PACK","100|300|300|800"),
             #[cfg(not(target_os = "windows"))]
             ("MASQ_REAL_USER", "9999:9999:booga"),
             ("MASQ_SCANS", "off"),
@@ -1977,7 +1979,7 @@ mod tests {
                 Set,
             ),
             ("payment-thresholds", "4321|66666|777|987|123456|124444", Set),
-            ("rate-pack", "10|30|13|28", Set),
+            ("rate-pack", "1000|3000|1300|2800", Set),
             #[cfg(not(target_os = "windows"))]
             ("real-user", "6666:6666:agoob", Set),
             ("scan-intervals", "111|111|111", Set),
@@ -2011,7 +2013,7 @@ mod tests {
             ("neighborhood-mode", "originate-only", Configured),
             ("neighbors", "masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@1.2.3.4:1234,masq://base-sepolia:MTIzNDU2Nzg5MTEyMzQ1Njc4OTIxMjM0NTY3ODkzMTI@5.6.7.8:5678", Configured),
             ("payment-thresholds","1234|50000|1000|1000|20000|20000",Configured),
-            ("rate-pack","1|3|3|8",Configured),
+            ("rate-pack","100|300|300|800",Configured),
             #[cfg(not(target_os = "windows"))]
             ("real-user", "9999:9999:booga", Configured),
             ("scan-intervals","150|150|155",Configured),

--- a/node/src/database/db_initializer.rs
+++ b/node/src/database/db_initializer.rs
@@ -668,7 +668,7 @@ mod tests {
     #[test]
     fn constants_have_correct_values() {
         assert_eq!(DATABASE_FILE, "node-data.db");
-        assert_eq!(CURRENT_SCHEMA_VERSION, 11);
+        assert_eq!(CURRENT_SCHEMA_VERSION, 12);
     }
 
     #[test]
@@ -968,6 +968,12 @@ mod tests {
         );
         verify(
             &mut config_vec,
+            "rate_pack_limits",
+            Some(DEFAULT_RATE_PACK_LIMITS),
+            false,
+        );
+        verify(
+            &mut config_vec,
             "scan_intervals",
             Some(&DEFAULT_SCAN_INTERVALS.to_string()),
             false,
@@ -1076,6 +1082,12 @@ mod tests {
             &mut config_vec,
             "rate_pack",
             Some(&DEFAULT_RATE_PACK.to_string()),
+            false,
+        );
+        verify(
+            &mut config_vec,
+            "rate_pack_limits",
+            Some(DEFAULT_RATE_PACK_LIMITS),
             false,
         );
         verify(

--- a/node/src/database/db_initializer.rs
+++ b/node/src/database/db_initializer.rs
@@ -5,7 +5,7 @@ use crate::database::db_migrations::db_migrator::{DbMigrator, DbMigratorReal};
 use crate::db_config::secure_config_layer::EXAMPLE_ENCRYPTED;
 use crate::neighborhood::DEFAULT_MIN_HOPS;
 use crate::sub_lib::accountant::{DEFAULT_PAYMENT_THRESHOLDS, DEFAULT_SCAN_INTERVALS};
-use crate::sub_lib::neighborhood::DEFAULT_RATE_PACK;
+use crate::sub_lib::neighborhood::{DEFAULT_RATE_PACK, DEFAULT_RATE_PACK_LIMITS};
 use crate::sub_lib::utils::db_connection_launch_panic;
 use masq_lib::blockchains::chains::Chain;
 use masq_lib::constants::{
@@ -255,6 +255,13 @@ impl DbInitializerReal {
             Some(&DEFAULT_RATE_PACK.to_string()),
             false,
             "rate pack",
+        );
+        Self::set_config_value(
+            conn,
+            "rate_pack_limits",
+            Some(DEFAULT_RATE_PACK_LIMITS),
+            false,
+            "rate pack limits",
         );
         Self::set_config_value(
             conn,

--- a/node/src/database/db_initializer.rs
+++ b/node/src/database/db_initializer.rs
@@ -259,7 +259,11 @@ impl DbInitializerReal {
         Self::set_config_value(
             conn,
             "rate_pack_limits",
-            Some(DEFAULT_RATE_PACK_LIMITS.rate_pack_limits_parameter().as_str()),
+            Some(
+                DEFAULT_RATE_PACK_LIMITS
+                    .rate_pack_limits_parameter()
+                    .as_str(),
+            ),
             false,
             "rate pack limits",
         );
@@ -969,7 +973,11 @@ mod tests {
         verify(
             &mut config_vec,
             "rate_pack_limits",
-            Some(DEFAULT_RATE_PACK_LIMITS.rate_pack_limits_parameter().as_str()),
+            Some(
+                DEFAULT_RATE_PACK_LIMITS
+                    .rate_pack_limits_parameter()
+                    .as_str(),
+            ),
             false,
         );
         verify(
@@ -1087,7 +1095,11 @@ mod tests {
         verify(
             &mut config_vec,
             "rate_pack_limits",
-            Some(DEFAULT_RATE_PACK_LIMITS.rate_pack_limits_parameter().as_str()),
+            Some(
+                DEFAULT_RATE_PACK_LIMITS
+                    .rate_pack_limits_parameter()
+                    .as_str(),
+            ),
             false,
         );
         verify(

--- a/node/src/database/db_initializer.rs
+++ b/node/src/database/db_initializer.rs
@@ -259,7 +259,7 @@ impl DbInitializerReal {
         Self::set_config_value(
             conn,
             "rate_pack_limits",
-            Some(DEFAULT_RATE_PACK_LIMITS),
+            Some(DEFAULT_RATE_PACK_LIMITS.rate_pack_limits_parameter().as_str()),
             false,
             "rate pack limits",
         );
@@ -969,7 +969,7 @@ mod tests {
         verify(
             &mut config_vec,
             "rate_pack_limits",
-            Some(DEFAULT_RATE_PACK_LIMITS),
+            Some(DEFAULT_RATE_PACK_LIMITS.rate_pack_limits_parameter().as_str()),
             false,
         );
         verify(
@@ -1087,7 +1087,7 @@ mod tests {
         verify(
             &mut config_vec,
             "rate_pack_limits",
-            Some(DEFAULT_RATE_PACK_LIMITS),
+            Some(DEFAULT_RATE_PACK_LIMITS.rate_pack_limits_parameter().as_str()),
             false,
         );
         verify(

--- a/node/src/database/db_migrations/db_migrator.rs
+++ b/node/src/database/db_migrations/db_migrator.rs
@@ -17,6 +17,7 @@ use crate::database::db_migrations::migrator_utils::{
 };
 use crate::database::rusqlite_wrappers::{ConnectionWrapper, TransactionSafeWrapper};
 use masq_lib::logger::Logger;
+use crate::database::db_migrations::migrations::migration_11_to_12::Migrate_11_to_12;
 
 pub trait DbMigrator {
     fn migrate_database(
@@ -82,6 +83,7 @@ impl DbMigratorReal {
             &Migrate_8_to_9,
             &Migrate_9_to_10,
             &Migrate_10_to_11,
+            &Migrate_11_to_12,
         ]
     }
 

--- a/node/src/database/db_migrations/db_migrator.rs
+++ b/node/src/database/db_migrations/db_migrator.rs
@@ -3,6 +3,7 @@
 use crate::database::db_initializer::ExternalData;
 use crate::database::db_migrations::migrations::migration_0_to_1::Migrate_0_to_1;
 use crate::database::db_migrations::migrations::migration_10_to_11::Migrate_10_to_11;
+use crate::database::db_migrations::migrations::migration_11_to_12::Migrate_11_to_12;
 use crate::database::db_migrations::migrations::migration_1_to_2::Migrate_1_to_2;
 use crate::database::db_migrations::migrations::migration_2_to_3::Migrate_2_to_3;
 use crate::database::db_migrations::migrations::migration_3_to_4::Migrate_3_to_4;
@@ -17,7 +18,6 @@ use crate::database::db_migrations::migrator_utils::{
 };
 use crate::database::rusqlite_wrappers::{ConnectionWrapper, TransactionSafeWrapper};
 use masq_lib::logger::Logger;
-use crate::database::db_migrations::migrations::migration_11_to_12::Migrate_11_to_12;
 
 pub trait DbMigrator {
     fn migrate_database(

--- a/node/src/database/db_migrations/migrations/migration_11_to_12.rs
+++ b/node/src/database/db_migrations/migrations/migration_11_to_12.rs
@@ -12,12 +12,10 @@ impl DatabaseMigration for Migrate_11_to_12 {
         &self,
         declaration_utils: Box<dyn DBMigDeclarator + 'a>,
     ) -> rusqlite::Result<()> {
-        declaration_utils.execute_upon_transaction(&[
-            &format!(
-                "INSERT INTO config (name, value, encrypted) VALUES ('rate_pack_limits', '{}', 0)",
-                DEFAULT_RATE_PACK_LIMITS
-            )
-        ])
+        declaration_utils.execute_upon_transaction(&[&format!(
+            "INSERT INTO config (name, value, encrypted) VALUES ('rate_pack_limits', '{}', 0)",
+            DEFAULT_RATE_PACK_LIMITS
+        )])
     }
 
     fn old_version(&self) -> usize {
@@ -65,7 +63,13 @@ mod tests {
         let connection = result.unwrap();
         let (lc_value, lc_encrypted) = retrieve_config_row(connection.as_ref(), "rate_pack_limits");
         let (cs_value, cs_encrypted) = retrieve_config_row(connection.as_ref(), "schema_version");
-        assert_eq!(lc_value, Some("100-100000000000000|100-100000000000000|100-100000000000000|100-100000000000000".to_string()));
+        assert_eq!(
+            lc_value,
+            Some(
+                "100-100000000000000|100-100000000000000|100-100000000000000|100-100000000000000"
+                    .to_string()
+            )
+        );
         assert_eq!(lc_encrypted, false);
         assert_eq!(cs_value, Some("12".to_string()));
         assert_eq!(cs_encrypted, false)

--- a/node/src/database/db_migrations/migrations/migration_11_to_12.rs
+++ b/node/src/database/db_migrations/migrations/migration_11_to_12.rs
@@ -14,7 +14,7 @@ impl DatabaseMigration for Migrate_11_to_12 {
     ) -> rusqlite::Result<()> {
         declaration_utils.execute_upon_transaction(&[&format!(
             "INSERT INTO config (name, value, encrypted) VALUES ('rate_pack_limits', '{}', 0)",
-            DEFAULT_RATE_PACK_LIMITS
+            DEFAULT_RATE_PACK_LIMITS.rate_pack_limits_parameter()
         )])
     }
 

--- a/node/src/database/db_migrations/migrations/migration_11_to_12.rs
+++ b/node/src/database/db_migrations/migrations/migration_11_to_12.rs
@@ -1,0 +1,73 @@
+// Copyright (c) 2019, MASQ (https://masq.ai) and/or its affiliates. All rights reserved.
+
+use crate::database::db_migrations::db_migrator::DatabaseMigration;
+use crate::database::db_migrations::migrator_utils::DBMigDeclarator;
+use crate::sub_lib::neighborhood::DEFAULT_RATE_PACK_LIMITS;
+
+#[allow(non_camel_case_types)]
+pub struct Migrate_11_to_12;
+
+impl DatabaseMigration for Migrate_11_to_12 {
+    fn migrate<'a>(
+        &self,
+        declaration_utils: Box<dyn DBMigDeclarator + 'a>,
+    ) -> rusqlite::Result<()> {
+        declaration_utils.execute_upon_transaction(&[
+            &format!(
+                "INSERT INTO config (name, value, encrypted) VALUES ('rate_pack_limits', '{}', 0)",
+                DEFAULT_RATE_PACK_LIMITS
+            )
+        ])
+    }
+
+    fn old_version(&self) -> usize {
+        11
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::database::db_initializer::{
+        DbInitializationConfig, DbInitializer, DbInitializerReal, DATABASE_FILE,
+    };
+    use crate::test_utils::database_utils::{
+        bring_db_0_back_to_life_and_return_connection, make_external_data, retrieve_config_row,
+    };
+    use masq_lib::test_utils::utils::ensure_node_home_directory_exists;
+    use std::fs::create_dir_all;
+
+    #[test]
+    fn migration_from_11_to_12_is_properly_set() {
+        let dir_path = ensure_node_home_directory_exists(
+            "db_migrations",
+            "migration_from_11_to_12_is_properly_set",
+        );
+        create_dir_all(&dir_path).unwrap();
+        let db_path = dir_path.join(DATABASE_FILE);
+        let _ = bring_db_0_back_to_life_and_return_connection(&db_path);
+        let subject = DbInitializerReal::default();
+
+        let result = subject.initialize_to_version(
+            &dir_path,
+            11,
+            DbInitializationConfig::create_or_migrate(make_external_data()),
+        );
+
+        assert!(result.is_ok());
+
+        let result = subject.initialize_to_version(
+            &dir_path,
+            12,
+            DbInitializationConfig::create_or_migrate(make_external_data()),
+        );
+
+        assert!(result.is_ok());
+        let connection = result.unwrap();
+        let (lc_value, lc_encrypted) = retrieve_config_row(connection.as_ref(), "rate_pack_limits");
+        let (cs_value, cs_encrypted) = retrieve_config_row(connection.as_ref(), "schema_version");
+        assert_eq!(lc_value, Some("100-100000000000000|100-100000000000000|100-100000000000000|100-100000000000000".to_string()));
+        assert_eq!(lc_encrypted, false);
+        assert_eq!(cs_value, Some("12".to_string()));
+        assert_eq!(cs_encrypted, false)
+    }
+}

--- a/node/src/database/db_migrations/migrations/mod.rs
+++ b/node/src/database/db_migrations/migrations/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2019, MASQ (https://masq.ai) and/or its affiliates. All rights reserved.
 
 pub mod migration_0_to_1;
+pub mod migration_10_to_11;
+pub mod migration_11_to_12;
 pub mod migration_1_to_2;
 pub mod migration_2_to_3;
 pub mod migration_3_to_4;
@@ -10,5 +12,3 @@ pub mod migration_6_to_7;
 pub mod migration_7_to_8;
 pub mod migration_8_to_9;
 pub mod migration_9_to_10;
-pub mod migration_10_to_11;
-pub mod migration_11_to_12;

--- a/node/src/database/db_migrations/migrations/mod.rs
+++ b/node/src/database/db_migrations/migrations/mod.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2019, MASQ (https://masq.ai) and/or its affiliates. All rights reserved.
 
 pub mod migration_0_to_1;
-pub mod migration_10_to_11;
 pub mod migration_1_to_2;
 pub mod migration_2_to_3;
 pub mod migration_3_to_4;
@@ -11,3 +10,5 @@ pub mod migration_6_to_7;
 pub mod migration_7_to_8;
 pub mod migration_8_to_9;
 pub mod migration_9_to_10;
+pub mod migration_10_to_11;
+pub mod migration_11_to_12;

--- a/node/src/db_config/config_dao_null.rs
+++ b/node/src/db_config/config_dao_null.rs
@@ -5,7 +5,7 @@ use crate::database::rusqlite_wrappers::TransactionSafeWrapper;
 use crate::db_config::config_dao::{ConfigDao, ConfigDaoError, ConfigDaoRecord};
 use crate::neighborhood::DEFAULT_MIN_HOPS;
 use crate::sub_lib::accountant::{DEFAULT_PAYMENT_THRESHOLDS, DEFAULT_SCAN_INTERVALS};
-use crate::sub_lib::neighborhood::DEFAULT_RATE_PACK;
+use crate::sub_lib::neighborhood::{DEFAULT_RATE_PACK, DEFAULT_RATE_PACK_LIMITS};
 use itertools::Itertools;
 use masq_lib::blockchains::chains::Chain;
 use masq_lib::constants::{CURRENT_SCHEMA_VERSION, DEFAULT_GAS_PRICE};
@@ -137,6 +137,10 @@ impl Default for ConfigDaoNull {
         data.insert(
             "rate_pack".to_string(),
             (Some(DEFAULT_RATE_PACK.to_string()), false),
+        );
+        data.insert(
+            "rate_pack_limits".to_string(),
+            (Some(DEFAULT_RATE_PACK_LIMITS.to_string()), false),
         );
         data.insert(
             "scan_intervals".to_string(),

--- a/node/src/db_config/config_dao_null.rs
+++ b/node/src/db_config/config_dao_null.rs
@@ -140,7 +140,10 @@ impl Default for ConfigDaoNull {
         );
         data.insert(
             "rate_pack_limits".to_string(),
-            (Some(DEFAULT_RATE_PACK_LIMITS.rate_pack_limits_parameter()), false),
+            (
+                Some(DEFAULT_RATE_PACK_LIMITS.rate_pack_limits_parameter()),
+                false,
+            ),
         );
         data.insert(
             "scan_intervals".to_string(),

--- a/node/src/db_config/config_dao_null.rs
+++ b/node/src/db_config/config_dao_null.rs
@@ -140,7 +140,7 @@ impl Default for ConfigDaoNull {
         );
         data.insert(
             "rate_pack_limits".to_string(),
-            (Some(DEFAULT_RATE_PACK_LIMITS.to_string()), false),
+            (Some(DEFAULT_RATE_PACK_LIMITS.rate_pack_limits_parameter()), false),
         );
         data.insert(
             "scan_intervals".to_string(),

--- a/node/src/neighborhood/dot_graph.rs
+++ b/node/src/neighborhood/dot_graph.rs
@@ -18,7 +18,7 @@ pub struct NodeRenderableInner {
 pub struct NodeRenderable {
     pub inner: Option<NodeRenderableInner>,
     pub public_key: PublicKey,
-    pub node_addr: Option<NodeAddr>,
+    pub node_addr_opt: Option<NodeAddr>,
     pub known_source: bool,
     pub known_target: bool,
     pub is_present: bool,
@@ -60,7 +60,7 @@ impl NodeRenderable {
         } else {
             &public_key_str
         };
-        let node_addr_string = match self.node_addr {
+        let node_addr_string = match self.node_addr_opt {
             None => String::new(),
             Some(ref na) => format!("\\n{}", na),
         };
@@ -112,7 +112,7 @@ mod tests {
                 country_code: "ZZ".to_string(),
             }),
             public_key: public_key.clone(),
-            node_addr: None,
+            node_addr_opt: None,
             known_source: false,
             known_target: false,
             is_present: true,
@@ -141,7 +141,7 @@ mod tests {
                 country_code: "ZZ".to_string(),
             }),
             public_key: public_key.clone(),
-            node_addr: None,
+            node_addr_opt: None,
             known_source: false,
             known_target: false,
             is_present: true,

--- a/node/src/neighborhood/gossip.rs
+++ b/node/src/neighborhood/gossip.rs
@@ -390,7 +390,7 @@ impl Gossip_0v1 {
                     country_code,
                 }),
                 public_key: nri.public_key.clone(),
-                node_addr: addr.clone(),
+                node_addr_opt: addr.clone(),
                 known_source: nri.public_key == source.public_key,
                 known_target: nri.public_key == target.public_key,
                 is_present: true,
@@ -400,7 +400,7 @@ impl Gossip_0v1 {
             node_renderables.push(NodeRenderable {
                 inner: None,
                 public_key: k.clone(),
-                node_addr: None,
+                node_addr_opt: None,
                 known_source: false,
                 known_target: false,
                 is_present: false,

--- a/node/src/neighborhood/gossip.rs
+++ b/node/src/neighborhood/gossip.rs
@@ -25,7 +25,7 @@ use itertools::Itertools;
 pub struct GossipNodeRecord {
     pub signed_data: PlainData,
     pub signature: CryptData,
-    pub node_addr_opt: Option<NodeAddr>,
+    pub node_addr_opt: Option<NodeAddr>, // TODO: Think about the implications of not signing this.
 }
 
 impl Debug for GossipNodeRecord {

--- a/node/src/neighborhood/gossip.rs
+++ b/node/src/neighborhood/gossip.rs
@@ -9,17 +9,17 @@ use crate::sub_lib::cryptde::{CryptDE, CryptData, PlainData, PublicKey};
 use crate::sub_lib::hopper::MessageType;
 use crate::sub_lib::node_addr::NodeAddr;
 use crate::sub_lib::versioned_data::StepError;
+use itertools::Itertools;
 use pretty_hex::PrettyHex;
 use serde_cbor::Value;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::convert::{TryFrom, TryInto};
-use std::fmt::{Debug, Display};
 use std::fmt::Error;
 use std::fmt::Formatter;
 use std::fmt::Write as _;
+use std::fmt::{Debug, Display};
 use std::net::{IpAddr, SocketAddr};
-use itertools::Itertools;
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GossipNodeRecord {
@@ -480,7 +480,8 @@ impl Display for AccessibleGossipRecord {
             Some(ref addr) => {
                 let mut index_of_space_after_pk = 9;
                 while (index_of_space_after_pk < inner_string.len())
-                    && (&inner_string[index_of_space_after_pk..index_of_space_after_pk + 1] != " ") {
+                    && (&inner_string[index_of_space_after_pk..index_of_space_after_pk + 1] != " ")
+                {
                     index_of_space_after_pk += 1;
                 }
                 let addr_string = addr.ip_addr().to_string();
@@ -638,7 +639,7 @@ mod tests {
 
     #[test]
     fn accessible_gossip_record_to_string_without_ip() {
-        let node_record = make_node_record (1234, true);
+        let node_record = make_node_record(1234, true);
         let db = db_from_node(&node_record);
         let subject = AccessibleGossipRecord::from((&db, node_record.public_key(), false));
 
@@ -652,7 +653,7 @@ mod tests {
 
     #[test]
     fn accessible_gossip_record_to_string_with_ip() {
-        let node_record = make_node_record (1234, true);
+        let node_record = make_node_record(1234, true);
         let db = db_from_node(&node_record);
         let subject = AccessibleGossipRecord::from((&db, node_record.public_key(), true));
 

--- a/node/src/neighborhood/gossip.rs
+++ b/node/src/neighborhood/gossip.rs
@@ -14,11 +14,12 @@ use serde_cbor::Value;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::convert::{TryFrom, TryInto};
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::fmt::Error;
 use std::fmt::Formatter;
 use std::fmt::Write as _;
 use std::net::{IpAddr, SocketAddr};
+use itertools::Itertools;
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GossipNodeRecord {
@@ -472,6 +473,31 @@ pub struct AccessibleGossipRecord {
     pub inner: NodeRecordInner_0v1,
 }
 
+impl Display for AccessibleGossipRecord {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let inner_string = self.inner.to_string();
+        match self.node_addr_opt {
+            Some(ref addr) => {
+                let mut index_of_space_after_pk = 9;
+                while (index_of_space_after_pk < inner_string.len())
+                    && (&inner_string[index_of_space_after_pk..index_of_space_after_pk + 1] != " ") {
+                    index_of_space_after_pk += 1;
+                }
+                let addr_string = addr.ip_addr().to_string();
+                let pieces = vec![
+                    &inner_string[0..index_of_space_after_pk],
+                    addr_string.as_str(),
+                    &inner_string[index_of_space_after_pk + 1..],
+                ];
+                write!(f, "{}", pieces.join(" "))
+            }
+            None => {
+                write!(f, "{}", self.inner)
+            }
+        }
+    }
+}
+
 impl AccessibleGossipRecord {
     pub fn regenerate_signed_gossip(&mut self, cryptde: &dyn CryptDE) {
         let (signed_gossip, signature) = regenerate_signed_gossip(&self.inner, cryptde);
@@ -507,6 +533,11 @@ pub fn regenerate_signed_gossip(
         Err(e) => unimplemented!("TODO: Signing error: {:?}", e),
     };
     (signed_gossip, signature)
+}
+
+pub fn agrs_to_string(agrs: &[AccessibleGossipRecord]) -> String {
+    let elements = agrs.iter().map(|it| it.to_string()).join(", ");
+    format!("[{}]", elements)
 }
 
 #[cfg(test)]
@@ -603,6 +634,34 @@ mod tests {
 
         let mut gossip = builder.build();
         assert_eq!(gossip.node_records.remove(0).node_addr_opt, None)
+    }
+
+    #[test]
+    fn accessible_gossip_record_to_string_without_ip() {
+        let node_record = make_node_record (1234, true);
+        let db = db_from_node(&node_record);
+        let subject = AccessibleGossipRecord::from((&db, node_record.public_key(), false));
+
+        let result = subject.to_string();
+
+        assert_eq!(
+            result,
+            "AR v0 AD AQIDBA 0x546900db8d6e0937497133d1ae6fdf5f4b75bcd0 1235|1434|1237|1634 []"
+        );
+    }
+
+    #[test]
+    fn accessible_gossip_record_to_string_with_ip() {
+        let node_record = make_node_record (1234, true);
+        let db = db_from_node(&node_record);
+        let subject = AccessibleGossipRecord::from((&db, node_record.public_key(), true));
+
+        let result = subject.to_string();
+
+        assert_eq!(
+            result,
+            "AR v0 AD AQIDBA 1.2.3.4 0x546900db8d6e0937497133d1ae6fdf5f4b75bcd0 1235|1434|1237|1634 []"
+        );
     }
 
     #[test]

--- a/node/src/neighborhood/gossip_acceptor.rs
+++ b/node/src/neighborhood/gossip_acceptor.rs
@@ -305,6 +305,7 @@ impl DebutHandler {
             }
             None => (),
         }
+todo!("Drive in a call to GossipAcceptorReal::validate_new_version() here");
         let debut_node_key = database
             .add_node(debuting_node)
             .expect("Debuting Node suddenly appeared in database");
@@ -1411,6 +1412,10 @@ impl GossipAcceptorReal {
             debut_target.inner.public_key.clone(),
             debut_target_node_addr.clone(),
         ))
+    }
+
+    fn validate_new_version(node_record: &NodeRecord, neighborhood_database: &NeighborhoodDatabase) -> bool {
+        todo!("Test-drive me")
     }
 }
 

--- a/node/src/neighborhood/gossip_acceptor.rs
+++ b/node/src/neighborhood/gossip_acceptor.rs
@@ -9,7 +9,10 @@ use crate::neighborhood::neighborhood_database::{NeighborhoodDatabase, Neighborh
 use crate::neighborhood::node_record::NodeRecord;
 use crate::neighborhood::UserExitPreferences;
 use crate::sub_lib::cryptde::{CryptDE, PublicKey};
-use crate::sub_lib::neighborhood::{ConnectionProgressEvent, ConnectionProgressMessage, GossipFailure_0v1, NeighborhoodMetadata, RatePackLimits, DEFAULT_RATE_PACK_LIMITS};
+use crate::sub_lib::neighborhood::{
+    ConnectionProgressEvent, ConnectionProgressMessage, GossipFailure_0v1, NeighborhoodMetadata,
+    RatePackLimits, DEFAULT_RATE_PACK_LIMITS,
+};
 use crate::sub_lib::node_addr::NodeAddr;
 use itertools::Itertools;
 use masq_lib::logger::Logger;
@@ -1129,7 +1132,9 @@ impl GossipHandler for StandardGossipHandler {
     ) -> Vec<GossipAcceptanceResult> {
         let initial_neighborship_status =
             StandardGossipHandler::check_full_neighbor(database, gossip_source.ip());
-        let gossip_source_agr = match agrs.iter().find(|agr| agr.node_addr_opt.as_ref().map(|na| na.ip_addr()) == Some(gossip_source.ip())) {
+        let gossip_source_agr = match agrs.iter().find(|agr| {
+            agr.node_addr_opt.as_ref().map(|na| na.ip_addr()) == Some(gossip_source.ip())
+        }) {
             Some(agr) => agr.clone(),
             None => {
                 let message = format!(
@@ -1138,12 +1143,12 @@ impl GossipHandler for StandardGossipHandler {
                 );
                 warning!(self.logger, "{}", message);
                 return vec![GossipAcceptanceResult::Ban(Malefactor::new(
-                        None,
-                        Some(gossip_source.ip()),
-                        None,
-                        None,
-                        message,
-                ))]
+                    None,
+                    Some(gossip_source.ip()),
+                    None,
+                    None,
+                    message,
+                ))];
             }
         };
         let patch = self.compute_patch(&agrs, database.root(), neighborhood_metadata.db_patch_size);
@@ -3498,7 +3503,8 @@ mod tests {
         dest_db.add_arbitrary_full_neighbor(dest_root.public_key(), src_root.public_key());
         src_db.add_node(dest_db.root().clone()).unwrap();
         src_db.add_arbitrary_full_neighbor(src_root.public_key(), dest_root.public_key());
-        let subject = StandardGossipHandler::new(&RatePackLimits::test_default(), Logger::new(test_name));
+        let subject =
+            StandardGossipHandler::new(&RatePackLimits::test_default(), Logger::new(test_name));
         let cryptde = CryptDENull::from(dest_db.root().public_key(), TEST_DEFAULT_CHAIN);
         let gossip_source: SocketAddr = src_root.node_addr_opt().unwrap().into();
         let (cpm_recipient, _) = make_cpm_recipient();
@@ -3519,15 +3525,13 @@ mod tests {
         );
         assert_eq!(
             handle_result,
-            vec![
-                GossipAcceptanceResult::Ban(Malefactor::new(
-                    None,
-                    Some(gossip_source.ip()),
-                    None,
-                    None,
-                    message.clone()
-                )),
-            ]
+            vec![GossipAcceptanceResult::Ban(Malefactor::new(
+                None,
+                Some(gossip_source.ip()),
+                None,
+                None,
+                message.clone()
+            )),]
         );
         TestLogHandler::new().exists_log_containing(&format!("WARN: {}: {}", test_name, message));
     }

--- a/node/src/neighborhood/gossip_acceptor.rs
+++ b/node/src/neighborhood/gossip_acceptor.rs
@@ -342,25 +342,36 @@ impl DebutHandler {
                         Some(node_addr) => node_addr.ip_addr().to_string(),
                         None => "?.?.?.?".to_string(),
                     };
-                    match GossipAcceptorReal::make_debut_triple(database, debuting_agr) {
-                        Ok((redebut_gossip, public_key, node_addr)) => {
-                            debug!(
-                                self.logger,
-                                "Node {} at {} can't send introduction; sending redebut instead",
-                                debuting_agr.inner.public_key,
-                                ip_addr_str
-                            );
-                            Ok(GossipAcceptanceResult::Reply(redebut_gossip, public_key, node_addr))
-                        }
-                        Err(e) => {
-                            debug!(
-                                self.logger,
-                                "Node {} at {} can send neither introduction nor redebut ({}); sending standard Gossip instead",
-                                debuting_agr.inner.public_key,
-                                ip_addr_str,
-                                e
-                            );
-                            Ok(GossipAcceptanceResult::Accepted)
+                    if Self::counts_us_among_neighbors(debuting_agr, database) {
+                        debug!(
+                                    self.logger,
+                                    "Can't send introduction to Node {} at {}, but it already knows us; sending Standard Gossip",
+                                    &debut_node_key,
+                                    gossip_source,
+                                );
+                        Ok(GossipAcceptanceResult::Accepted)
+                    }
+                    else {
+                        match GossipAcceptorReal::make_debut_triple(database, debuting_agr) {
+                            Ok((redebut_gossip, public_key, node_addr)) => {
+                                debug!(
+                                    self.logger,
+                                    "Can't send introduction to Node {} at {}; sending redebut instead",
+                                    debuting_agr.inner.public_key,
+                                    ip_addr_str
+                                );
+                                Ok(GossipAcceptanceResult::Reply(redebut_gossip, public_key, node_addr))
+                            }
+                            Err(e) => {
+                                debug!(
+                                    self.logger,
+                                    "Can't send either introduction or redebut to Node {} at {} ({}); sending standard Gossip instead",
+                                    debuting_agr.inner.public_key,
+                                    ip_addr_str,
+                                    e
+                                );
+                                Ok(GossipAcceptanceResult::Accepted)
+                            }
                         }
                     }
                 } else {
@@ -373,37 +384,57 @@ impl DebutHandler {
                             ))
                         },
                         IntroductionAttempt::Failure => {
-                            debug!(
-                                self.logger,
-                                "DebutHandler has no one to introduce, but is debuting back to {} at {}",
-                                &debut_node_key,
-                                gossip_source,
-                            );
                             trace!(
                                 self.logger,
                                 "DebutHandler database state: {}",
                                 &database.to_dot_graph(),
                             );
-                            let debut_gossip = Self::create_second_node_gossip_response(
-                                cryptde,
-                                database,
-                                debut_node_key,
-                            );
-                            Ok(GossipAcceptanceResult::Reply(
-                                debut_gossip,
-                                debuting_agr.inner.public_key.clone(),
-                                debuting_agr
-                                    .node_addr_opt
-                                    .as_ref()
-                                    .expect("Debut gossip always has an IP")
-                                    .clone(),
-                            ))
+                            if Self::counts_us_among_neighbors(debuting_agr, database) {
+                                debug!(
+                                    self.logger,
+                                    "DebutHandler has no one to introduce and debutant already has us as a neighbor; accepting {} at {} and sending Standard Gossip",
+                                    &debut_node_key,
+                                    gossip_source,
+                                );
+                                Ok(GossipAcceptanceResult::Accepted)
+                            }
+                            else {
+                                debug!(
+                                    self.logger,
+                                    "DebutHandler has no one to introduce, but debutant does not have us as a neighbor; debuting back to {} at {}",
+                                    &debut_node_key,
+                                    gossip_source,
+                                );
+                                let debut_gossip = Self::create_second_node_gossip_response(
+                                    cryptde,
+                                    database,
+                                    debut_node_key,
+                                );
+                                Ok(GossipAcceptanceResult::Reply(
+                                    debut_gossip,
+                                    debuting_agr.inner.public_key.clone(),
+                                    debuting_agr
+                                        .node_addr_opt
+                                        .as_ref()
+                                        .expect("Debut gossip always has an IP")
+                                        .clone(),
+                                ))
+                            }
                         }
                     }
                 }
             }
             Ok(false) => panic!("Brand-new neighbor already existed"),
         }
+    }
+
+    fn counts_us_among_neighbors(debuting_agr: &AccessibleGossipRecord, database: &NeighborhoodDatabase) -> bool {
+        let our_key = database.root().public_key();
+        debuting_agr
+            .inner
+            .neighbors
+            .iter()
+            .any(|pk| pk == our_key)
     }
 
     fn create_second_node_gossip_response(
@@ -1172,8 +1203,18 @@ impl GossipHandler for StandardGossipHandler {
         let initial_neighborship_status =
             StandardGossipHandler::check_full_neighbor(database, gossip_source.ip());
         let gossip_source_agr = match agrs.iter().find(|agr| {
-            agr.inner.accepts_connections &&
-                (agr.node_addr_opt.as_ref().map(|na| na.ip_addr()) == Some(gossip_source.ip()))
+            if agr.inner.accepts_connections {
+                // If it accepts connections, it'll know its IP address, and we can match on gossip_source
+                agr.node_addr_opt.as_ref().map(|na| na.ip_addr()) == Some(gossip_source.ip())
+            } else {
+                // If it doesn't, we'll know its IP address but it won't, so we'll look it up by IP
+                // and check public keys.
+                if let Some(db_node) = database.node_by_ip(&gossip_source.ip()) {
+                    db_node.public_key() == &agr.inner.public_key
+                } else {
+                    false
+                }
+            }
         }) {
             Some(agr) => agr.clone(), // TODO: Why clone? Why not just reference?
             None => {
@@ -1198,7 +1239,7 @@ impl GossipHandler for StandardGossipHandler {
             .collect_vec();
 
         let (worthy_agrs, malefactor_bans) =
-            self.extract_malefactors(in_patch_agrs, database, &gossip_source_agr);
+            self.extract_malefactors(in_patch_agrs, database, &gossip_source_agr, gossip_source);
         let mut db_changed = false;
 
         let (new_agrs, obsolete_agrs) =
@@ -1338,12 +1379,11 @@ impl StandardGossipHandler {
         agrs: Vec<AccessibleGossipRecord>,
         database: &NeighborhoodDatabase,
         gossip_source_agr: &AccessibleGossipRecord,
+        // If our gossip_source_agr doesn't accept connections, it won't have an IP address; so
+        // we accept that separately.
+        gossip_source: SocketAddr,
     ) -> (Vec<AccessibleGossipRecord>, Vec<GossipAcceptanceResult>) {
-        let gossip_source_ip = gossip_source_agr
-            .node_addr_opt
-            .as_ref()
-            .expect("NodeAddr on gossip source disappeared")
-            .ip_addr();
+        let gossip_source_ip = gossip_source.ip();
         // TODO: This would be more consistent with identify_non_introductory_new_and_obsolete_nodes
         // below if it used a for loop with mutation.
         let (valid_agrs, bans) = agrs.into_iter().fold((vec![], vec![]), |so_far, agr| {
@@ -2201,8 +2241,8 @@ mod tests {
     }
 
     #[test]
-    fn if_we_have_neighbors_but_none_qualify_for_introduction_or_pass_then_debut_back() {
-        let test_name = "if_we_have_neighbors_but_none_qualify_for_introduction_or_pass_then_debut_back";
+    fn if_we_have_neighbors_but_none_qualify_for_introduction_or_pass_and_does_not_half_neighbor_us_then_debut_back() {
+        let test_name = "if_we_have_neighbors_but_none_qualify_for_introduction_or_pass_and_does_not_half_neighbor_us_then_debut_back";
         let dest_root = make_node_record(1234, true);
         let root_node_cryptde = CryptDENull::from(&dest_root.public_key(), TEST_DEFAULT_CHAIN);
         let one_common_neighbor = make_node_record(4321, true); // can't introduce this one; debutant already knows it
@@ -2244,6 +2284,54 @@ mod tests {
             debutant.public_key().clone(),
             debutant.node_addr_opt().expect("Debutant should have NodeAddr"),
         ));
+        assert!(dest_db.root().half_neighbor_keys().contains(debutant.public_key()));
+        assert_eq!(dest_db.root().version(), original_version + 1);
+        root_node_cryptde.verify_signature(
+            dest_db.root().signed_gossip(),
+            dest_db.root().signature(),
+            dest_db.root().public_key()
+        );
+    }
+
+    #[test]
+    fn if_we_have_neighbors_but_none_qualify_for_introduction_or_pass_and_half_neighbors_us_then_standard_gossip() {
+        let test_name = "if_we_have_neighbors_but_none_qualify_for_introduction_or_pass_and_half_neighbors_us_then_standard_gossip";
+        let dest_root = make_node_record(1234, true);
+        let root_node_cryptde = CryptDENull::from(&dest_root.public_key(), TEST_DEFAULT_CHAIN);
+        let one_common_neighbor = make_node_record(4321, true); // can't introduce this one; debutant already knows it
+        let another_common_neighbor = make_node_record(5432, true); // can't introduce this one; debutant already knows it
+        let mut dest_db = db_from_node(&dest_root);
+        dest_db.add_node(one_common_neighbor.clone()).unwrap();
+        dest_db.add_arbitrary_full_neighbor(
+            dest_root.public_key(),
+            one_common_neighbor.public_key(),
+        );
+        dest_db.add_node(another_common_neighbor.clone()).unwrap();
+        dest_db.add_arbitrary_full_neighbor(
+            dest_root.public_key(),
+            another_common_neighbor.public_key(),
+        );
+        let original_version = dest_db.root().version();
+
+        let mut debutant = make_node_record(4567, true);
+        debutant.inner.neighbors.insert(one_common_neighbor.public_key().clone());
+        debutant.inner.neighbors.insert(another_common_neighbor.public_key().clone());
+        debutant.inner.neighbors.insert(dest_root.public_key().clone());
+        let logger = Logger::new(test_name);
+        let subject = DebutHandler::new(&RatePackLimits::test_default(), logger);
+        let neighborhood_metadata = make_default_neighborhood_metadata();
+
+        let result = subject
+            .try_accept_debut(
+                &root_node_cryptde,
+                &mut dest_db,
+                &AccessibleGossipRecord::from(&debutant),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(4, 5, 6, 7)), 4567),
+                neighborhood_metadata.user_exit_preferences_opt,
+            )
+            .unwrap();
+
+        assert_eq!(result, GossipAcceptanceResult::Accepted);
         assert!(dest_db.root().half_neighbor_keys().contains(debutant.public_key()));
         assert_eq!(dest_db.root().version(), original_version + 1);
         root_node_cryptde.verify_signature(
@@ -3706,6 +3794,68 @@ mod tests {
             )),]
         );
         TestLogHandler::new().exists_log_containing(&format!("WARN: {}: {}", test_name, message));
+    }
+
+    #[test]
+    fn standard_gossip_from_node_that_does_not_accept_connections_is_accepted() {
+        /*
+          Destination Node ==>
+            S---D
+
+          Source Node ==>
+           S---D
+
+          The source node(S) will send Gossip containing a record describing itself that
+          carries no IP address, since it does not accept connections; but it won't be
+          rejected.
+        */
+        init_test_logging();
+        let test_name = "standard_gossip_from_node_that_does_not_accept_connections_is_accepted";
+        let mut src_root = make_node_record(1234, true);
+        let gossip_source: SocketAddr = src_root.node_addr_opt().unwrap().into();
+        src_root.inner.accepts_connections = false;
+        src_root.metadata.node_addr_opt = None;
+        src_root.resign();
+        let neighbor_1 = make_node_record(2345, false);
+        let neighbor_2 = make_node_record(3456, false);
+        let dest_root = make_node_record(4567, true);
+        let mut src_db = db_from_node(&src_root);
+        let mut dest_db = db_from_node(&dest_root);
+        // The destination Node knows the IP address of the source, even if the source doesn't
+        let mut src_root_with_node_addr = src_root.clone();
+        src_root_with_node_addr.metadata.node_addr_opt = Some(NodeAddr::new(&gossip_source.ip(), &[gossip_source.port()]));
+        dest_db.add_node(src_root_with_node_addr).unwrap();
+        dest_db.add_arbitrary_full_neighbor(dest_root.public_key(), src_root.public_key());
+        src_db.add_node(dest_db.root().clone()).unwrap();
+        src_db.add_arbitrary_full_neighbor(src_root.public_key(), dest_root.public_key());
+        src_db.add_node(neighbor_1.clone()).unwrap();
+        src_db.add_arbitrary_full_neighbor(src_root.public_key(), neighbor_1.public_key());
+        src_db.add_node(neighbor_2.clone()).unwrap();
+        src_db.add_arbitrary_full_neighbor(src_root.public_key(), neighbor_2.public_key());
+        let subject =
+            StandardGossipHandler::new(&RatePackLimits::test_default(), Logger::new(test_name));
+        let cryptde = CryptDENull::from(dest_db.root().public_key(), TEST_DEFAULT_CHAIN);
+        let (cpm_recipient, _) = make_cpm_recipient();
+        let mut neighborhood_metadata = make_default_neighborhood_metadata();
+        neighborhood_metadata.cpm_recipient = cpm_recipient;
+        let gossip = GossipBuilder::new(&src_db)
+            .node(src_root.public_key(), false)
+            .node(neighbor_1.public_key(), true)
+            .node(neighbor_2.public_key(), true)
+            .build();
+
+        let handle_result = subject.handle(
+            &cryptde,
+            &mut dest_db,
+            gossip.try_into().unwrap(),
+            gossip_source,
+            neighborhood_metadata,
+        );
+
+        assert_eq!(
+            handle_result,
+            vec![GossipAcceptanceResult::Accepted]
+        )
     }
 
     #[test]

--- a/node/src/neighborhood/gossip_acceptor.rs
+++ b/node/src/neighborhood/gossip_acceptor.rs
@@ -92,7 +92,10 @@ impl GossipHandler for DebutHandler {
         gossip_source: SocketAddr,
     ) -> Qualification {
         if agrs.len() != 1 {
-            return Qualification::Unmatched(format!("Debut has 1 Node record, not {}", agrs.len()));
+            return Qualification::Unmatched(format!(
+                "Debut has 1 Node record, not {}",
+                agrs.len()
+            ));
         }
         if database.node_by_key(&agrs[0].inner.public_key).is_some() {
             return Qualification::Unmatched("Node record already in database".to_string());
@@ -270,8 +273,7 @@ impl DebutHandler {
         let qualified_neighbors: Vec<&PublicKey> = neighbor_vec
             .into_iter()
             .filter(|k| {
-                let node = database.node_by_key(*k)
-                    .expect("Node disappeared");
+                let node = database.node_by_key(*k).expect("Node disappeared");
                 node.accepts_connections() && node.routes_data()
             })
             .skip_while(|k| database.gossip_target_degree(*k) <= 2)
@@ -350,8 +352,7 @@ impl DebutHandler {
                                     gossip_source,
                                 );
                         Ok(GossipAcceptanceResult::Accepted)
-                    }
-                    else {
+                    } else {
                         match GossipAcceptorReal::make_debut_triple(database, debuting_agr) {
                             Ok((redebut_gossip, public_key, node_addr)) => {
                                 debug!(
@@ -360,7 +361,11 @@ impl DebutHandler {
                                     debuting_agr.inner.public_key,
                                     ip_addr_str
                                 );
-                                Ok(GossipAcceptanceResult::Reply(redebut_gossip, public_key, node_addr))
+                                Ok(GossipAcceptanceResult::Reply(
+                                    redebut_gossip,
+                                    public_key,
+                                    node_addr,
+                                ))
                             }
                             Err(e) => {
                                 debug!(
@@ -376,13 +381,15 @@ impl DebutHandler {
                     }
                 } else {
                     match self.try_to_make_introduction(database, debuting_agr, gossip_source) {
-                        IntroductionAttempt::Success(introduction, target_key, target_node_addr) => {
-                            Ok(GossipAcceptanceResult::Reply(
-                                introduction,
-                                target_key,
-                                target_node_addr,
-                            ))
-                        },
+                        IntroductionAttempt::Success(
+                            introduction,
+                            target_key,
+                            target_node_addr,
+                        ) => Ok(GossipAcceptanceResult::Reply(
+                            introduction,
+                            target_key,
+                            target_node_addr,
+                        )),
                         IntroductionAttempt::Failure => {
                             trace!(
                                 self.logger,
@@ -397,8 +404,7 @@ impl DebutHandler {
                                     gossip_source,
                                 );
                                 Ok(GossipAcceptanceResult::Accepted)
-                            }
-                            else {
+                            } else {
                                 debug!(
                                     self.logger,
                                     "DebutHandler has no one to introduce, but debutant does not have us as a neighbor; debuting back to {} at {}",
@@ -428,13 +434,12 @@ impl DebutHandler {
         }
     }
 
-    fn counts_us_among_neighbors(debuting_agr: &AccessibleGossipRecord, database: &NeighborhoodDatabase) -> bool {
+    fn counts_us_among_neighbors(
+        debuting_agr: &AccessibleGossipRecord,
+        database: &NeighborhoodDatabase,
+    ) -> bool {
         let our_key = database.root().public_key();
-        debuting_agr
-            .inner
-            .neighbors
-            .iter()
-            .any(|pk| pk == our_key)
+        debuting_agr.inner.neighbors.iter().any(|pk| pk == our_key)
     }
 
     fn create_second_node_gossip_response(
@@ -499,8 +504,7 @@ impl DebutHandler {
                 debuting_agr.inner.public_key.clone(),
                 debut_node_addr,
             )
-        }
-        else {
+        } else {
             IntroductionAttempt::Failure
         }
     }
@@ -581,13 +585,19 @@ impl DebutHandler {
         keys
     }
 
-    fn should_not_make_another_introduction(db: &NeighborhoodDatabase, debuting_agr: &AccessibleGossipRecord) -> bool {
-        let routing_neighbors = debuting_agr.inner.neighbors.iter().filter(|pk| {
-            match db.node_by_key(pk) {
-                Some(node) => node.inner.routes_data,
-                None => false,
-            }
-        });
+    fn should_not_make_another_introduction(
+        db: &NeighborhoodDatabase,
+        debuting_agr: &AccessibleGossipRecord,
+    ) -> bool {
+        let routing_neighbors =
+            debuting_agr
+                .inner
+                .neighbors
+                .iter()
+                .filter(|pk| match db.node_by_key(pk) {
+                    Some(node) => node.inner.routes_data,
+                    None => false,
+                });
         routing_neighbors.count() > 0
     }
 
@@ -634,7 +644,9 @@ impl GossipHandler for PassHandler {
                         node_addr.ip_addr()
                     ))
                 } else if node_addr.ip_addr() == gossip_source.ip() {
-                    Qualification::Unmatched("Pass Node record must not be Gossip source".to_string())
+                    Qualification::Unmatched(
+                        "Pass Node record must not be Gossip source".to_string(),
+                    )
                 } else {
                     Qualification::Matched
                 }
@@ -757,7 +769,8 @@ impl GossipHandler for IntroductionHandler {
         if let Some(qual) = Self::verify_introducer(introducer, database.root()) {
             return qual;
         };
-        if let Some(qual) = Self::verify_introducee(database, introducer, introducee, gossip_source) {
+        if let Some(qual) = Self::verify_introducee(database, introducer, introducee, gossip_source)
+        {
             return qual;
         };
         if let Some(qual) = Self::verify_both(database, introducer, introducee) {
@@ -915,7 +928,10 @@ impl IntroductionHandler {
 
     fn verify_size(agrs: &[AccessibleGossipRecord]) -> Option<Qualification> {
         if agrs.len() != 2 {
-            return Some(Qualification::Unmatched(format!("Introduction has 2 Node records, not {}", agrs.len())))
+            return Some(Qualification::Unmatched(format!(
+                "Introduction has 2 Node records, not {}",
+                agrs.len()
+            )));
         }
         None
     }
@@ -926,12 +942,20 @@ impl IntroductionHandler {
     ) -> Result<bool, Qualification> {
         let first_agr = &agrs_ref[0];
         let first_ip = match first_agr.node_addr_opt.as_ref() {
-            None => return Err(Qualification::Unmatched("Both Node records in Introduction must have NodeAddr".to_string())),
+            None => {
+                return Err(Qualification::Unmatched(
+                    "Both Node records in Introduction must have NodeAddr".to_string(),
+                ))
+            }
             Some(node_addr) => node_addr.ip_addr(),
         };
         let second_agr = &agrs_ref[1];
         let second_ip = match second_agr.node_addr_opt.as_ref() {
-            None => return Err(Qualification::Unmatched("Both Node records in Introduction must have NodeAddr".to_string())),
+            None => {
+                return Err(Qualification::Unmatched(
+                    "Both Node records in Introduction must have NodeAddr".to_string(),
+                ))
+            }
             Some(node_addr) => node_addr.ip_addr(),
         };
         if first_ip == gossip_source.ip() {
@@ -977,7 +1001,10 @@ impl IntroductionHandler {
                 introducer.inner.public_key
             )));
         }
-        let introducer_node_addr = introducer.node_addr_opt.as_ref().expect("NodeAddr disappeared");
+        let introducer_node_addr = introducer
+            .node_addr_opt
+            .as_ref()
+            .expect("NodeAddr disappeared");
         if introducer_node_addr.ports().is_empty() {
             return Some(Qualification::Malformed(format!(
                 "Introducer {} from {} has no ports",
@@ -1003,7 +1030,11 @@ impl IntroductionHandler {
         gossip_source: SocketAddr,
     ) -> Option<Qualification> {
         let introducee_node_addr = match introducee.node_addr_opt.as_ref() {
-            None => return Some(Qualification::Unmatched("Introducee has no NodeAddr".to_string())),
+            None => {
+                return Some(Qualification::Unmatched(
+                    "Introducee has no NodeAddr".to_string(),
+                ))
+            }
             Some(node_addr) => node_addr,
         };
         if introducee_node_addr.ports().is_empty() {
@@ -1041,10 +1072,13 @@ impl IntroductionHandler {
         introducee: &AccessibleGossipRecord,
     ) -> Option<Qualification> {
         let half_neighbors = db.root().half_neighbor_keys();
-        if half_neighbors.contains(&introducee.inner.public_key) && half_neighbors.contains(&introducer.inner.public_key) {
-            Some(Qualification::Unmatched("Introducer and introducee are already our half-neighbors".to_string()))
-        }
-        else {
+        if half_neighbors.contains(&introducee.inner.public_key)
+            && half_neighbors.contains(&introducer.inner.public_key)
+        {
+            Some(Qualification::Unmatched(
+                "Introducer and introducee are already our half-neighbors".to_string(),
+            ))
+        } else {
             None
         }
     }
@@ -1704,22 +1738,18 @@ impl GossipAcceptor for GossipAcceptorReal {
                 panic!("Nothing in gossip_handlers returned Matched or Malformed")
             }
             Qualification::Malformed(reason) => {
-                let (
-                    public_key_opt,
-                    ip_address_opt,
-                    earning_wallet_opt,
-                ) = match agrs.iter().find(|agr| {
-                    agr.node_addr_opt.as_ref().map(|na| na.ip_addr()) == Some(gossip_source.ip())
-                }) {
-                    Some(agr) => (
-                        Some(agr.inner.public_key.clone()),
-                        Some(gossip_source.ip()),
-                        Some(agr.inner.earning_wallet.clone()),
-                    ),
-                    None => {
-                        (None, Some(gossip_source.ip()), None)
-                    },
-                };
+                let (public_key_opt, ip_address_opt, earning_wallet_opt) =
+                    match agrs.iter().find(|agr| {
+                        agr.node_addr_opt.as_ref().map(|na| na.ip_addr())
+                            == Some(gossip_source.ip())
+                    }) {
+                        Some(agr) => (
+                            Some(agr.inner.public_key.clone()),
+                            Some(gossip_source.ip()),
+                            Some(agr.inner.earning_wallet.clone()),
+                        ),
+                        None => (None, Some(gossip_source.ip()), None),
+                    };
                 vec![GossipAcceptanceResult::Ban(Malefactor::new(
                     public_key_opt,
                     ip_address_opt,
@@ -1727,7 +1757,7 @@ impl GossipAcceptor for GossipAcceptorReal {
                     None,
                     reason,
                 ))]
-            },
+            }
         }
     }
 }
@@ -1807,7 +1837,7 @@ impl GossipAcceptorReal {
                     warning!(logger, "{}", message.as_str());
                     Err(message)
                 }
-            }
+            };
         }
         Ok(())
     }
@@ -1855,7 +1885,10 @@ mod tests {
         UNREACHABLE_COUNTRY_PENALTY,
     };
     use crate::sub_lib::cryptde_null::CryptDENull;
-    use crate::sub_lib::neighborhood::{ConnectionProgressEvent, ConnectionProgressMessage, RatePack, DEFAULT_RATE_PACK, ZERO_RATE_PACK};
+    use crate::sub_lib::neighborhood::{
+        ConnectionProgressEvent, ConnectionProgressMessage, RatePack, DEFAULT_RATE_PACK,
+        ZERO_RATE_PACK,
+    };
     use crate::sub_lib::utils::time_t_timestamp;
     use crate::test_utils::neighborhood_test_utils::{
         db_from_node, gossip_about_nodes_from_database, linearly_connect_nodes,
@@ -1872,12 +1905,12 @@ mod tests {
     use masq_lib::messages::ExitLocation;
     use masq_lib::test_utils::logging::{init_test_logging, TestLogHandler};
     use masq_lib::test_utils::utils::TEST_DEFAULT_CHAIN;
+    use masq_lib::utils::NeighborhoodModeLight;
     use std::convert::TryInto;
     use std::net::Ipv4Addr;
     use std::ops::{Add, Sub};
     use std::str::FromStr;
     use std::time::Duration;
-    use masq_lib::utils::NeighborhoodModeLight;
 
     lazy_static! {
         static ref GA_CRYPTDE_PAIR: CryptDEPair = CryptDEPair::null();
@@ -1910,7 +1943,9 @@ mod tests {
                 NeighborhoodModeLight::Standard => Mode::new(true, true),
                 NeighborhoodModeLight::OriginateOnly => Mode::new(false, true),
                 NeighborhoodModeLight::ConsumeOnly => Mode::new(false, false),
-                NeighborhoodModeLight::ZeroHop => unimplemented!("ZeroHop should not be used in GossipAcceptor tests"),
+                NeighborhoodModeLight::ZeroHop => {
+                    unimplemented!("ZeroHop should not be used in GossipAcceptor tests")
+                }
             }
         }
     }
@@ -1935,7 +1970,8 @@ mod tests {
 
     #[test]
     fn proper_debut_of_accepting_node_with_populated_database_is_identified_and_handled() {
-        let (gossip, new_node, gossip_source_opt) = make_debut(2345, NeighborhoodModeLight::Standard.into());
+        let (gossip, new_node, gossip_source_opt) =
+            make_debut(2345, NeighborhoodModeLight::Standard.into());
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let neighbor_key = &db.add_node(make_node_record(3456, true)).unwrap();
@@ -1971,7 +2007,8 @@ mod tests {
 
     #[test]
     fn proper_debut_of_non_accepting_node_with_populated_database_is_identified_and_handled() {
-        let (gossip, new_node, gossip_source) = make_debut(2345, NeighborhoodModeLight::OriginateOnly.into());
+        let (gossip, new_node, gossip_source) =
+            make_debut(2345, NeighborhoodModeLight::OriginateOnly.into());
         let root_node = make_node_record(1234, true);
         let mut dest_db = db_from_node(&root_node);
         let neighbor_key = &dest_db.add_node(make_node_record(3456, true)).unwrap();
@@ -1980,7 +2017,8 @@ mod tests {
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
         let subject = DebutHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
 
-        let qualifies_result = subject.qualifies(&dest_db, agrs_vec.as_slice(), gossip_source.clone());
+        let qualifies_result =
+            subject.qualifies(&dest_db, agrs_vec.as_slice(), gossip_source.clone());
         let handle_result = subject.handle(
             &cryptde,
             &mut dest_db,
@@ -2004,10 +2042,11 @@ mod tests {
         );
         // Version of debuting Node in destination database should have NodeAddr
         // even though it doesn't accept connections
-        let debuted_node = dest_db
-            .node_by_key(&new_node.public_key())
-            .unwrap();
-        assert_eq!(debuted_node.metadata.node_addr_opt, Some(NodeAddr::from(&gossip_source)));
+        let debuted_node = dest_db.node_by_key(&new_node.public_key()).unwrap();
+        assert_eq!(
+            debuted_node.metadata.node_addr_opt,
+            Some(NodeAddr::from(&gossip_source))
+        );
     }
 
     #[test]
@@ -2051,7 +2090,8 @@ mod tests {
 
     #[test]
     fn debut_with_node_addr_not_accepting_connections_is_rejected() {
-        let (mut gossip, _j, gossip_source) = make_debut(2345, NeighborhoodModeLight::OriginateOnly.into());
+        let (mut gossip, _j, gossip_source) =
+            make_debut(2345, NeighborhoodModeLight::OriginateOnly.into());
         let subject = DebutHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
         gossip.node_records[0].node_addr_opt = Some(NodeAddr::new(
             &IpAddr::from_str("1.2.3.4").unwrap(),
@@ -2071,7 +2111,8 @@ mod tests {
 
     #[test]
     fn debut_without_node_addr_accepting_connections_is_rejected() {
-        let (mut gossip, _j, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into());
+        let (mut gossip, _j, gossip_source) =
+            make_debut(2345, NeighborhoodModeLight::Standard.into());
         gossip.node_records[0].node_addr_opt = None;
         let subject = DebutHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
@@ -2088,7 +2129,8 @@ mod tests {
 
     #[test]
     fn debut_without_node_addr_ports_accepting_connections_is_rejected() {
-        let (mut gossip, _, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into());
+        let (mut gossip, _, gossip_source) =
+            make_debut(2345, NeighborhoodModeLight::Standard.into());
         gossip.node_records[0].node_addr_opt =
             Some(NodeAddr::new(&IpAddr::from_str("1.2.3.4").unwrap(), &[]));
         let subject = DebutHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
@@ -2106,7 +2148,8 @@ mod tests {
 
     #[test]
     fn apparent_debut_with_node_already_in_database_is_unmatched() {
-        let (gossip, new_node, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into());
+        let (gossip, new_node, gossip_source) =
+            make_debut(2345, NeighborhoodModeLight::Standard.into());
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let neighbor_key = &db.add_node(make_node_record(3456, true)).unwrap();
@@ -2117,7 +2160,10 @@ mod tests {
 
         let result = subject.qualifies(&db, agrs_vec.as_slice(), gossip_source);
 
-        assert_eq!(result, Qualification::Unmatched("Node record already in database".to_string()));
+        assert_eq!(
+            result,
+            Qualification::Unmatched("Node record already in database".to_string())
+        );
     }
 
     #[test]
@@ -2241,7 +2287,8 @@ mod tests {
     }
 
     #[test]
-    fn if_we_have_neighbors_but_none_qualify_for_introduction_or_pass_and_does_not_half_neighbor_us_then_debut_back() {
+    fn if_we_have_neighbors_but_none_qualify_for_introduction_or_pass_and_does_not_half_neighbor_us_then_debut_back(
+    ) {
         let test_name = "if_we_have_neighbors_but_none_qualify_for_introduction_or_pass_and_does_not_half_neighbor_us_then_debut_back";
         let dest_root = make_node_record(1234, true);
         let root_node_cryptde = CryptDENull::from(&dest_root.public_key(), TEST_DEFAULT_CHAIN);
@@ -2249,10 +2296,8 @@ mod tests {
         let another_common_neighbor = make_node_record(5432, true); // can't introduce this one; debutant already knows it
         let mut dest_db = db_from_node(&dest_root);
         dest_db.add_node(one_common_neighbor.clone()).unwrap();
-        dest_db.add_arbitrary_full_neighbor(
-            dest_root.public_key(),
-            one_common_neighbor.public_key(),
-        );
+        dest_db
+            .add_arbitrary_full_neighbor(dest_root.public_key(), one_common_neighbor.public_key());
         dest_db.add_node(another_common_neighbor.clone()).unwrap();
         dest_db.add_arbitrary_full_neighbor(
             dest_root.public_key(),
@@ -2261,8 +2306,14 @@ mod tests {
         let original_version = dest_db.root().version();
 
         let mut debutant = make_node_record(4567, true);
-        debutant.inner.neighbors.insert(one_common_neighbor.public_key().clone());
-        debutant.inner.neighbors.insert(another_common_neighbor.public_key().clone());
+        debutant
+            .inner
+            .neighbors
+            .insert(one_common_neighbor.public_key().clone());
+        debutant
+            .inner
+            .neighbors
+            .insert(another_common_neighbor.public_key().clone());
         let logger = Logger::new(test_name);
         let subject = DebutHandler::new(&RatePackLimits::test_default(), logger);
         let neighborhood_metadata = make_default_neighborhood_metadata();
@@ -2277,24 +2328,33 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(result, GossipAcceptanceResult::Reply(
-            GossipBuilder::new(&dest_db)
-                .node(dest_db.root().public_key(), true)
-                .build(),
-            debutant.public_key().clone(),
-            debutant.node_addr_opt().expect("Debutant should have NodeAddr"),
-        ));
-        assert!(dest_db.root().half_neighbor_keys().contains(debutant.public_key()));
+        assert_eq!(
+            result,
+            GossipAcceptanceResult::Reply(
+                GossipBuilder::new(&dest_db)
+                    .node(dest_db.root().public_key(), true)
+                    .build(),
+                debutant.public_key().clone(),
+                debutant
+                    .node_addr_opt()
+                    .expect("Debutant should have NodeAddr"),
+            )
+        );
+        assert!(dest_db
+            .root()
+            .half_neighbor_keys()
+            .contains(debutant.public_key()));
         assert_eq!(dest_db.root().version(), original_version + 1);
         root_node_cryptde.verify_signature(
             dest_db.root().signed_gossip(),
             dest_db.root().signature(),
-            dest_db.root().public_key()
+            dest_db.root().public_key(),
         );
     }
 
     #[test]
-    fn if_we_have_neighbors_but_none_qualify_for_introduction_or_pass_and_half_neighbors_us_then_standard_gossip() {
+    fn if_we_have_neighbors_but_none_qualify_for_introduction_or_pass_and_half_neighbors_us_then_standard_gossip(
+    ) {
         let test_name = "if_we_have_neighbors_but_none_qualify_for_introduction_or_pass_and_half_neighbors_us_then_standard_gossip";
         let dest_root = make_node_record(1234, true);
         let root_node_cryptde = CryptDENull::from(&dest_root.public_key(), TEST_DEFAULT_CHAIN);
@@ -2302,10 +2362,8 @@ mod tests {
         let another_common_neighbor = make_node_record(5432, true); // can't introduce this one; debutant already knows it
         let mut dest_db = db_from_node(&dest_root);
         dest_db.add_node(one_common_neighbor.clone()).unwrap();
-        dest_db.add_arbitrary_full_neighbor(
-            dest_root.public_key(),
-            one_common_neighbor.public_key(),
-        );
+        dest_db
+            .add_arbitrary_full_neighbor(dest_root.public_key(), one_common_neighbor.public_key());
         dest_db.add_node(another_common_neighbor.clone()).unwrap();
         dest_db.add_arbitrary_full_neighbor(
             dest_root.public_key(),
@@ -2314,9 +2372,18 @@ mod tests {
         let original_version = dest_db.root().version();
 
         let mut debutant = make_node_record(4567, true);
-        debutant.inner.neighbors.insert(one_common_neighbor.public_key().clone());
-        debutant.inner.neighbors.insert(another_common_neighbor.public_key().clone());
-        debutant.inner.neighbors.insert(dest_root.public_key().clone());
+        debutant
+            .inner
+            .neighbors
+            .insert(one_common_neighbor.public_key().clone());
+        debutant
+            .inner
+            .neighbors
+            .insert(another_common_neighbor.public_key().clone());
+        debutant
+            .inner
+            .neighbors
+            .insert(dest_root.public_key().clone());
         let logger = Logger::new(test_name);
         let subject = DebutHandler::new(&RatePackLimits::test_default(), logger);
         let neighborhood_metadata = make_default_neighborhood_metadata();
@@ -2332,18 +2399,22 @@ mod tests {
             .unwrap();
 
         assert_eq!(result, GossipAcceptanceResult::Accepted);
-        assert!(dest_db.root().half_neighbor_keys().contains(debutant.public_key()));
+        assert!(dest_db
+            .root()
+            .half_neighbor_keys()
+            .contains(debutant.public_key()));
         assert_eq!(dest_db.root().version(), original_version + 1);
         root_node_cryptde.verify_signature(
             dest_db.root().signed_gossip(),
             dest_db.root().signature(),
-            dest_db.root().public_key()
+            dest_db.root().public_key(),
         );
     }
 
     #[test]
     fn proper_pass_is_identified_and_processed() {
-        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
+        let (gossip, pass_target, gossip_source) =
+            make_pass(2345, NeighborhoodModeLight::Standard.into());
         let subject = PassHandler::new();
         let mut dest_db = make_meaningless_db();
         let cryptde = CryptDENull::from(dest_db.root().public_key(), TEST_DEFAULT_CHAIN);
@@ -2376,39 +2447,40 @@ mod tests {
     fn pass_with_node_that_does_not_accept_connections_is_rejected() {
         let root_node = make_node_record(1234, true); // irrelevant
         let mut db = db_from_node(&root_node); // irrelevant
-        let (gossip, _pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::OriginateOnly.into());
+        let (gossip, _pass_target, gossip_source) =
+            make_pass(2345, NeighborhoodModeLight::OriginateOnly.into());
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
         let subject = PassHandler::new();
 
-        let result = subject.qualifies(
-            &mut db,
-            agrs_vec.as_slice(),
-            gossip_source,
-        );
+        let result = subject.qualifies(&mut db, agrs_vec.as_slice(), gossip_source);
 
-        assert_eq!(result, Qualification::Unmatched("Pass Node record always has a NodeAddr".to_string()));
+        assert_eq!(
+            result,
+            Qualification::Unmatched("Pass Node record always has a NodeAddr".to_string())
+        );
     }
 
     #[test]
     fn pass_with_node_that_does_not_route_data_is_rejected() {
         let root_node = make_node_record(1234, true); // irrelevant
         let mut db = db_from_node(&root_node); // irrelevant
-        let (gossip, _pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::ConsumeOnly.into());
+        let (gossip, _pass_target, gossip_source) =
+            make_pass(2345, NeighborhoodModeLight::ConsumeOnly.into());
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
         let subject = PassHandler::new();
 
-        let result = subject.qualifies(
-            &mut db,
-            agrs_vec.as_slice(),
-            gossip_source,
-        );
+        let result = subject.qualifies(&mut db, agrs_vec.as_slice(), gossip_source);
 
-        assert_eq!(result, Qualification::Unmatched("Pass Node record always has a NodeAddr".to_string()));
+        assert_eq!(
+            result,
+            Qualification::Unmatched("Pass Node record always has a NodeAddr".to_string())
+        );
     }
 
     #[test]
     fn pass_without_node_addr_is_rejected() {
-        let (mut gossip, _, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
+        let (mut gossip, _, gossip_source) =
+            make_pass(2345, NeighborhoodModeLight::Standard.into());
         gossip.node_records[0].node_addr_opt = None;
         let subject = PassHandler::new();
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
@@ -2423,7 +2495,8 @@ mod tests {
 
     #[test]
     fn pass_without_node_addr_ports_is_rejected() {
-        let (mut gossip, _, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
+        let (mut gossip, _, gossip_source) =
+            make_pass(2345, NeighborhoodModeLight::Standard.into());
         gossip.node_records[0].node_addr_opt =
             Some(NodeAddr::new(&IpAddr::from_str("1.2.3.4").unwrap(), &[]));
         let subject = PassHandler::new();
@@ -2449,7 +2522,10 @@ mod tests {
 
         let result = subject.qualifies(&make_meaningless_db(), agrs_vec.as_slice(), gossip_source);
 
-        assert_eq!(Qualification::Unmatched("Introduction has 2 Node records, not 1".to_string()), result);
+        assert_eq!(
+            Qualification::Unmatched("Introduction has 2 Node records, not 1".to_string()),
+            result
+        );
     }
 
     #[test]
@@ -2460,7 +2536,9 @@ mod tests {
         let dest_root = make_node_record(7878, true);
         let mut dest_db = db_from_node(&dest_root);
         dest_db.add_node(introducer_in_target_db.clone()).unwrap();
-        dest_db.add_half_neighbor(introducer_in_target_db.public_key()).unwrap(); //disqualifying
+        dest_db
+            .add_half_neighbor(introducer_in_target_db.public_key())
+            .unwrap(); //disqualifying
         dest_db.add_node(introducee_in_target_db.clone()).unwrap();
         let subject =
             IntroductionHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
@@ -2472,7 +2550,8 @@ mod tests {
     }
 
     #[test]
-    fn introduction_is_matched_if_receiver_has_half_neighborship_with_introducee_but_not_introducer() {
+    fn introduction_is_matched_if_receiver_has_half_neighborship_with_introducee_but_not_introducer(
+    ) {
         let (gossip, gossip_source) = make_introduction(2345, 3456);
         let introducer_in_target_db = make_node_record(2345, true);
         let introducee_in_target_db = make_node_record(3456, true);
@@ -2480,7 +2559,9 @@ mod tests {
         let mut dest_db = db_from_node(&dest_root);
         dest_db.add_node(introducer_in_target_db.clone()).unwrap();
         dest_db.add_node(introducee_in_target_db.clone()).unwrap();
-        dest_db.add_half_neighbor(introducee_in_target_db.public_key()).unwrap(); //disqualifying
+        dest_db
+            .add_half_neighbor(introducee_in_target_db.public_key())
+            .unwrap(); //disqualifying
         let subject =
             IntroductionHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
@@ -2491,23 +2572,33 @@ mod tests {
     }
 
     #[test]
-    fn introduction_is_unmatched_if_receiver_has_half_neighborships_with_both_introducer_and_introducee() {
+    fn introduction_is_unmatched_if_receiver_has_half_neighborships_with_both_introducer_and_introducee(
+    ) {
         let (gossip, gossip_source) = make_introduction(2345, 3456);
         let introducer_in_target_db = make_node_record(2345, true);
         let introducee_in_target_db = make_node_record(3456, true);
         let dest_root = make_node_record(7878, true);
         let mut dest_db = db_from_node(&dest_root);
         dest_db.add_node(introducer_in_target_db.clone()).unwrap();
-        dest_db.add_half_neighbor(introducer_in_target_db.public_key()).unwrap(); //disqualifying
+        dest_db
+            .add_half_neighbor(introducer_in_target_db.public_key())
+            .unwrap(); //disqualifying
         dest_db.add_node(introducee_in_target_db.clone()).unwrap();
-        dest_db.add_half_neighbor(introducee_in_target_db.public_key()).unwrap(); //disqualifying
+        dest_db
+            .add_half_neighbor(introducee_in_target_db.public_key())
+            .unwrap(); //disqualifying
         let subject =
             IntroductionHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
 
         let result = subject.qualifies(&dest_db, agrs_vec.as_slice(), gossip_source);
 
-        assert_eq!(result, Qualification::Unmatched("Introducer and introducee are already our half-neighbors".to_string()));
+        assert_eq!(
+            result,
+            Qualification::Unmatched(
+                "Introducer and introducee are already our half-neighbors".to_string()
+            )
+        );
     }
 
     #[test]
@@ -2522,7 +2613,12 @@ mod tests {
 
         let result = subject.qualifies(&dest_db, agrs_vec.as_slice(), gossip_source);
 
-        assert_eq!(Qualification::Unmatched("Both Node records in Introduction must have NodeAddr".to_string()), result);
+        assert_eq!(
+            Qualification::Unmatched(
+                "Both Node records in Introduction must have NodeAddr".to_string()
+            ),
+            result
+        );
     }
 
     #[test]
@@ -2556,7 +2652,12 @@ mod tests {
 
         let result = subject.qualifies(&dest_db, agrs_vec.as_slice(), gossip_source);
 
-        assert_eq!(Qualification::Unmatched("Both Node records in Introduction must have NodeAddr".to_string()), result);
+        assert_eq!(
+            Qualification::Unmatched(
+                "Both Node records in Introduction must have NodeAddr".to_string()
+            ),
+            result
+        );
     }
 
     #[test]
@@ -3742,7 +3843,8 @@ mod tests {
     }
 
     #[test]
-    fn standard_gossip_from_node_that_accepts_connections_but_does_not_describe_gossip_source_is_rejected() {
+    fn standard_gossip_from_node_that_accepts_connections_but_does_not_describe_gossip_source_is_rejected(
+    ) {
         /*
           Destination Node ==>
             S---D
@@ -3823,7 +3925,8 @@ mod tests {
         let mut dest_db = db_from_node(&dest_root);
         // The destination Node knows the IP address of the source, even if the source doesn't
         let mut src_root_with_node_addr = src_root.clone();
-        src_root_with_node_addr.metadata.node_addr_opt = Some(NodeAddr::new(&gossip_source.ip(), &[gossip_source.port()]));
+        src_root_with_node_addr.metadata.node_addr_opt =
+            Some(NodeAddr::new(&gossip_source.ip(), &[gossip_source.port()]));
         dest_db.add_node(src_root_with_node_addr).unwrap();
         dest_db.add_arbitrary_full_neighbor(dest_root.public_key(), src_root.public_key());
         src_db.add_node(dest_db.root().clone()).unwrap();
@@ -3852,10 +3955,7 @@ mod tests {
             neighborhood_metadata,
         );
 
-        assert_eq!(
-            handle_result,
-            vec![GossipAcceptanceResult::Accepted]
-        )
+        assert_eq!(handle_result, vec![GossipAcceptanceResult::Accepted])
     }
 
     #[test]
@@ -3911,7 +4011,8 @@ mod tests {
                 Some(malefactor_socket_addr.ip()),
                 None,
                 None,
-                "Node at 3.4.5.6 sent Standard gossip without a record describing itself".to_string()
+                "Node at 3.4.5.6 sent Standard gossip without a record describing itself"
+                    .to_string()
             ))]
         );
     }
@@ -4020,10 +4121,12 @@ mod tests {
         let subject = make_subject(GA_CRYPTDE_PAIR.main.as_ref());
         let reject_handler = subject.gossip_handlers.last().unwrap();
         let db = make_meaningless_db();
-        let (debut, _, debut_gossip_source) = make_debut(1234, NeighborhoodModeLight::Standard.into());
+        let (debut, _, debut_gossip_source) =
+            make_debut(1234, NeighborhoodModeLight::Standard.into());
         let (pass, _, pass_gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
         let (introduction, introduction_gossip_source) = make_introduction(3456, 4567);
-        let (standard_gossip, _, standard_gossip_source) = make_debut(9898, NeighborhoodModeLight::Standard.into());
+        let (standard_gossip, _, standard_gossip_source) =
+            make_debut(9898, NeighborhoodModeLight::Standard.into());
         let debut_vec: Vec<AccessibleGossipRecord> = debut.try_into().unwrap();
         let pass_vec: Vec<AccessibleGossipRecord> = pass.try_into().unwrap();
         let introduction_vec: Vec<AccessibleGossipRecord> = introduction.try_into().unwrap();
@@ -4104,7 +4207,8 @@ mod tests {
         let mut root_node = make_node_record(1234, true);
         let root_node_cryptde = CryptDENull::from(&root_node.public_key(), TEST_DEFAULT_CHAIN);
         let mut source_db = db_from_node(&root_node);
-        let (gossip, mut debut_node, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into()); //debut node is FR
+        let (gossip, mut debut_node, gossip_source) =
+            make_debut(2345, NeighborhoodModeLight::Standard.into()); //debut node is FR
         let mut expected_source_db = db_from_node(&root_node);
         expected_source_db
             .add_arbitrary_half_neighbor(root_node.public_key(), debut_node.public_key());
@@ -4170,7 +4274,8 @@ mod tests {
             .unwrap()
             .resign();
         dest_db.node_by_key_mut(existing_node_key).unwrap().resign();
-        let (gossip, mut debut_node, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into());
+        let (gossip, mut debut_node, gossip_source) =
+            make_debut(2345, NeighborhoodModeLight::Standard.into());
         let subject = make_subject(&root_node_cryptde);
         let before = time_t_timestamp();
 
@@ -4240,7 +4345,8 @@ mod tests {
             .unwrap()
             .resign();
 
-        let (gossip, mut debut_node, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into());
+        let (gossip, mut debut_node, gossip_source) =
+            make_debut(2345, NeighborhoodModeLight::Standard.into());
         let subject = make_subject(&root_node_cryptde);
         let before = time_t_timestamp();
 
@@ -4336,7 +4442,8 @@ mod tests {
             .unwrap()
             .resign();
 
-        let (gossip, debut_node, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into());
+        let (gossip, debut_node, gossip_source) =
+            make_debut(2345, NeighborhoodModeLight::Standard.into());
         let subject = make_subject(&root_node_cryptde);
 
         let result = subject.handle(
@@ -4426,7 +4533,8 @@ mod tests {
             .unwrap()
             .resign();
 
-        let (gossip, debut_node, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into());
+        let (gossip, debut_node, gossip_source) =
+            make_debut(2345, NeighborhoodModeLight::Standard.into());
         let subject = make_subject(&root_node_cryptde);
 
         let result = subject.handle(
@@ -4617,7 +4725,10 @@ mod tests {
         );
 
         let mut debut_back_node = dest_node.clone();
-        debut_back_node.inner.neighbors.insert(src_node.public_key().clone());
+        debut_back_node
+            .inner
+            .neighbors
+            .insert(src_node.public_key().clone());
         debut_back_node.increment_version();
         debut_back_node.resign();
         let gnr = GossipNodeRecord::from((
@@ -4630,13 +4741,11 @@ mod tests {
         };
         assert_eq!(
             result,
-            vec![
-                GossipAcceptanceResult::Reply(
-                    debut_back_gossip,
-                    src_node.public_key().clone(),
-                    src_node.node_addr_opt().unwrap().clone(),
-                )
-            ]
+            vec![GossipAcceptanceResult::Reply(
+                debut_back_gossip,
+                src_node.public_key().clone(),
+                src_node.node_addr_opt().unwrap().clone(),
+            )]
         )
     }
 
@@ -4666,7 +4775,10 @@ mod tests {
         );
 
         let mut debut_back_node = dest_node.clone();
-        debut_back_node.inner.neighbors.insert(src_node.public_key().clone());
+        debut_back_node
+            .inner
+            .neighbors
+            .insert(src_node.public_key().clone());
         debut_back_node.increment_version();
         debut_back_node.resign();
         let gnr = GossipNodeRecord::from((
@@ -4679,13 +4791,11 @@ mod tests {
         };
         assert_eq!(
             result,
-            vec![
-                GossipAcceptanceResult::Reply(
-                    debut_back_gossip,
-                    src_node.public_key().clone(),
-                    src_node.node_addr_opt().unwrap().clone(),
-                )
-            ]
+            vec![GossipAcceptanceResult::Reply(
+                debut_back_gossip,
+                src_node.public_key().clone(),
+                src_node.node_addr_opt().unwrap().clone(),
+            )]
         )
     }
 
@@ -4752,7 +4862,8 @@ mod tests {
         let test_name = "pass_is_properly_handled";
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
-        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
+        let (gossip, pass_target, gossip_source) =
+            make_pass(2345, NeighborhoodModeLight::Standard.into());
         let mut subject = make_subject(GA_CRYPTDE_PAIR.main.as_ref());
         subject.logger = Logger::new(test_name);
 
@@ -4775,13 +4886,13 @@ mod tests {
             )]
         );
         assert_eq!(db.keys().len(), 1);
-        TestLogHandler::new().exists_log_containing(format!(
-            "TRACE: {}: Gossip from {} did not qualify for {}: {}",
-            test_name,
-            gossip_source,
-            "DebutHandler",
-            "Node record is not Gossip source"
-        ).as_str());
+        TestLogHandler::new().exists_log_containing(
+            format!(
+                "TRACE: {}: Gossip from {} did not qualify for {}: {}",
+                test_name, gossip_source, "DebutHandler", "Node record is not Gossip source"
+            )
+            .as_str(),
+        );
     }
 
     #[test]
@@ -4790,7 +4901,8 @@ mod tests {
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let subject = PassHandler::new();
-        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
+        let (gossip, pass_target, gossip_source) =
+            make_pass(2345, NeighborhoodModeLight::Standard.into());
         let system = System::new("handles_a_new_pass_target");
         let (cpm_recipient, recording_arc) = make_cpm_recipient();
         let mut neighborhood_metadata = make_default_neighborhood_metadata();
@@ -4837,7 +4949,8 @@ mod tests {
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let subject = PassHandler::new();
-        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
+        let (gossip, pass_target, gossip_source) =
+            make_pass(2345, NeighborhoodModeLight::Standard.into());
         let pass_target_ip_addr = pass_target.node_addr_opt().unwrap().ip_addr();
         subject.previous_pass_targets.borrow_mut().insert(
             pass_target_ip_addr,
@@ -4884,7 +4997,8 @@ mod tests {
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let subject = PassHandler::new();
-        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
+        let (gossip, pass_target, gossip_source) =
+            make_pass(2345, NeighborhoodModeLight::Standard.into());
         let pass_target_ip_addr = pass_target.node_addr_opt().unwrap().ip_addr();
         let system =
             System::new("handles_pass_target_that_is_a_part_of_a_different_connection_progress");
@@ -4921,7 +5035,8 @@ mod tests {
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let subject = PassHandler::new();
-        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
+        let (gossip, pass_target, gossip_source) =
+            make_pass(2345, NeighborhoodModeLight::Standard.into());
         let (cpm_recipient, recording_arc) = make_cpm_recipient();
         let mut neighborhood_metadata = make_default_neighborhood_metadata();
         neighborhood_metadata.cpm_recipient = cpm_recipient;
@@ -5112,14 +5227,18 @@ mod tests {
         assert_eq!(dest_db.node_by_key(node_f.public_key()), None);
     }
 
-    struct MalformedHandler{}
-    impl NamedType for MalformedHandler { fn type_name(&self) -> &'static str { "MalformedHandler" } }
+    struct MalformedHandler {}
+    impl NamedType for MalformedHandler {
+        fn type_name(&self) -> &'static str {
+            "MalformedHandler"
+        }
+    }
     impl GossipHandler for MalformedHandler {
         fn qualifies(
             &self,
             _database: &NeighborhoodDatabase,
             _agrs: &[AccessibleGossipRecord],
-            _gossip_source: SocketAddr
+            _gossip_source: SocketAddr,
         ) -> Qualification {
             Qualification::Malformed("Malformed for test".to_string())
         }
@@ -5130,7 +5249,7 @@ mod tests {
             _database: &mut NeighborhoodDatabase,
             _agrs: Vec<AccessibleGossipRecord>,
             _gossip_source: SocketAddr,
-            _neighborhood_metadata: NeighborhoodMetadata
+            _neighborhood_metadata: NeighborhoodMetadata,
         ) -> Vec<GossipAcceptanceResult> {
             unimplemented!("Should never be called")
         }
@@ -5138,7 +5257,7 @@ mod tests {
 
     #[test]
     fn qualification_of_malformed_with_agr_produces_malefactor_ban() {
-        let malformed_handler = Box::new(MalformedHandler{});
+        let malformed_handler = Box::new(MalformedHandler {});
         let dest_root = make_node_record(1234, true);
         let mut dest_db = db_from_node(&dest_root); // irrelevant
         let src_root = make_node_record(2345, true);
@@ -5170,13 +5289,12 @@ mod tests {
 
     #[test]
     fn qualification_of_malformed_without_agr_produces_malefactor_ban() {
-        let malformed_handler = Box::new(MalformedHandler{});
+        let malformed_handler = Box::new(MalformedHandler {});
         let dest_root = make_node_record(1234, true);
         let mut dest_db = db_from_node(&dest_root); // irrelevant
         let src_root = make_node_record(2345, true);
         let src_db = db_from_node(&src_root);
-        let gossip = GossipBuilder::new(&src_db)
-            .build();
+        let gossip = GossipBuilder::new(&src_db).build();
         let mut subject = make_subject(GA_CRYPTDE_PAIR.main.as_ref());
         subject.gossip_handlers = vec![malformed_handler];
         let gossip_source = SocketAddr::from_str("5.5.5.5:5555").unwrap(); // not in Gossip

--- a/node/src/neighborhood/gossip_acceptor.rs
+++ b/node/src/neighborhood/gossip_acceptor.rs
@@ -44,7 +44,7 @@ pub enum GossipAcceptanceResult {
 #[derive(Clone, PartialEq, Eq, Debug)]
 enum Qualification {
     Matched,
-    Unmatched,
+    Unmatched(String),
     // TODO: Malformed will need to be modified to carry a Malefactor instead of a String
     Malformed(String),
 }
@@ -92,10 +92,10 @@ impl GossipHandler for DebutHandler {
         gossip_source: SocketAddr,
     ) -> Qualification {
         if agrs.len() != 1 {
-            return Qualification::Unmatched;
+            return Qualification::Unmatched(format!("Debut has 1 Node record, not {}", agrs.len()));
         }
         if database.node_by_key(&agrs[0].inner.public_key).is_some() {
-            return Qualification::Unmatched;
+            return Qualification::Unmatched("Node record already in database".to_string());
         }
         match &agrs[0].node_addr_opt {
             None => {
@@ -118,7 +118,7 @@ impl GossipHandler for DebutHandler {
                     } else if node_addr.ip_addr() == gossip_source.ip() {
                         Qualification::Matched
                     } else {
-                        Qualification::Unmatched
+                        Qualification::Unmatched("Node record is not Gossip source".to_string())
                     }
                 } else {
                     Qualification::Malformed(format!(
@@ -337,15 +337,32 @@ impl DebutHandler {
                 root_mut.increment_version();
                 root_mut.regenerate_signed_gossip(cryptde);
                 trace!(self.logger, "Current database: {}", database.to_dot_graph());
-                if Self::should_not_make_another_introduction(&database, debuting_agr) {
+                if Self::should_not_make_another_introduction(database, debuting_agr) {
                     let ip_addr_str = match &debuting_agr.node_addr_opt {
                         Some(node_addr) => node_addr.ip_addr().to_string(),
                         None => "?.?.?.?".to_string(),
                     };
-                    debug!(self.logger, "Node {} at {} is responding to first introduction: sending standard Gossip instead of further introduction",
-                                              debuting_agr.inner.public_key,
-                                              ip_addr_str);
-                    Ok(GossipAcceptanceResult::Accepted)
+                    match GossipAcceptorReal::make_debut_triple(database, debuting_agr) {
+                        Ok((redebut_gossip, public_key, node_addr)) => {
+                            debug!(
+                                self.logger,
+                                "Node {} at {} can't send introduction; sending redebut instead",
+                                debuting_agr.inner.public_key,
+                                ip_addr_str
+                            );
+                            Ok(GossipAcceptanceResult::Reply(redebut_gossip, public_key, node_addr))
+                        }
+                        Err(e) => {
+                            debug!(
+                                self.logger,
+                                "Node {} at {} can send neither introduction nor redebut ({}); sending standard Gossip instead",
+                                debuting_agr.inner.public_key,
+                                ip_addr_str,
+                                e
+                            );
+                            Ok(GossipAcceptanceResult::Accepted)
+                        }
+                    }
                 } else {
                     match self.try_to_make_introduction(database, debuting_agr, gossip_source) {
                         IntroductionAttempt::Success(introduction, target_key, target_node_addr) => {
@@ -540,7 +557,7 @@ impl DebutHandler {
                 None => false,
             }
         });
-        routing_neighbors.count() >= 2 // 2 is arbitrary choice
+        routing_neighbors.count() > 0
     }
 
     fn make_pass_gossip(database: &NeighborhoodDatabase, pass_target: &PublicKey) -> Gossip_0v1 {
@@ -573,10 +590,10 @@ impl GossipHandler for PassHandler {
         gossip_source: SocketAddr,
     ) -> Qualification {
         if agrs.len() != 1 {
-            return Qualification::Unmatched;
+            return Qualification::Unmatched(format!("Pass has 1 Node record, not {}", agrs.len()));
         }
         match &agrs[0].node_addr_opt {
-            None => Qualification::Unmatched,
+            None => Qualification::Unmatched("Pass Node record always has a NodeAddr".to_string()),
             Some(node_addr) => {
                 if node_addr.ports().is_empty() {
                     Qualification::Malformed(format!(
@@ -586,7 +603,7 @@ impl GossipHandler for PassHandler {
                         node_addr.ip_addr()
                     ))
                 } else if node_addr.ip_addr() == gossip_source.ip() {
-                    Qualification::Unmatched
+                    Qualification::Unmatched("Pass Node record must not be Gossip source".to_string())
                 } else {
                     Qualification::Matched
                 }
@@ -706,10 +723,13 @@ impl GossipHandler for IntroductionHandler {
                 Ok(true) => (&agrs[0], &agrs[1]),
                 Ok(false) => (&agrs[1], &agrs[0]),
             };
-        if let Some(qual) = Self::verify_introducer(database, introducer, database.root()) {
+        if let Some(qual) = Self::verify_introducer(introducer, database.root()) {
             return qual;
         };
         if let Some(qual) = Self::verify_introducee(database, introducer, introducee, gossip_source) {
+            return qual;
+        };
+        if let Some(qual) = Self::verify_both(database, introducer, introducee) {
             return qual;
         };
         Qualification::Matched
@@ -728,8 +748,8 @@ impl GossipHandler for IntroductionHandler {
         }
         let (introducer, introducee) = Self::identify_players(agrs, gossip_source)
             .expect("Introduction not properly qualified");
-        // TODO: Should be _opt. Also, think about some outboard methods.
-        let mut introducer_ban_message = GossipAcceptorReal::validate_new_version(
+        // TODO: Think about some outboard methods.
+        let mut introducer_ban_message_opt = GossipAcceptorReal::validate_new_version(
             &introducer,
             format!(
                 "Introducer {} from {}",
@@ -740,7 +760,7 @@ impl GossipHandler for IntroductionHandler {
         )
         .err();
         // TODO: Should be _opt
-        let introducee_ban_message = GossipAcceptorReal::validate_new_version(
+        let introducee_ban_message_opt = GossipAcceptorReal::validate_new_version(
             &introducee,
             format!(
                 "Introducee {} at {}",
@@ -768,7 +788,7 @@ impl GossipHandler for IntroductionHandler {
             .as_ref()
             .expect("Introducee IP address disappeared")
             .ip_addr();
-        let introducer_updated = if introducer_ban_message.is_none() {
+        let introducer_updated = if introducer_ban_message_opt.is_none() {
             match self.update_database(
                 database,
                 cryptde,
@@ -777,7 +797,7 @@ impl GossipHandler for IntroductionHandler {
             ) {
                 Ok(updated) => updated,
                 Err(e) => {
-                    introducer_ban_message = Some(format!(
+                    introducer_ban_message_opt = Some(format!(
                         "Introducer {} tried changing immutable characteristic: {}",
                         introducer_key, e
                     ));
@@ -788,7 +808,7 @@ impl GossipHandler for IntroductionHandler {
             false
         };
 
-        if introducee_ban_message.is_none() {
+        if introducee_ban_message_opt.is_none() {
             let connection_progress_message = ConnectionProgressMessage {
                 peer_addr: introducer_ip_addr,
                 event: ConnectionProgressEvent::IntroductionGossipReceived(introducee_ip_addr),
@@ -799,7 +819,7 @@ impl GossipHandler for IntroductionHandler {
                 .expect("Neighborhood is dead");
         }
 
-        let introducer_ban_opt = introducer_ban_message.as_ref().map(|message| {
+        let introducer_ban_opt = introducer_ban_message_opt.as_ref().map(|message| {
             GossipAcceptanceResult::Ban(Malefactor::new(
                 Some(introducer_key),
                 Some(introducer_ip_addr),
@@ -808,7 +828,7 @@ impl GossipHandler for IntroductionHandler {
                 message.clone(),
             ))
         });
-        let introducee_ban_opt = introducee_ban_message.as_ref().map(|message| {
+        let introducee_ban_opt = introducee_ban_message_opt.as_ref().map(|message| {
             GossipAcceptanceResult::Ban(Malefactor::new(
                 Some(introducee.inner.public_key.clone()),
                 Some(introducee_ip_addr),
@@ -864,7 +884,7 @@ impl IntroductionHandler {
 
     fn verify_size(agrs: &[AccessibleGossipRecord]) -> Option<Qualification> {
         if agrs.len() != 2 {
-            return Some(Qualification::Unmatched);
+            return Some(Qualification::Unmatched(format!("Introduction has 2 Node records, not {}", agrs.len())))
         }
         None
     }
@@ -875,12 +895,12 @@ impl IntroductionHandler {
     ) -> Result<bool, Qualification> {
         let first_agr = &agrs_ref[0];
         let first_ip = match first_agr.node_addr_opt.as_ref() {
-            None => return Err(Qualification::Unmatched),
+            None => return Err(Qualification::Unmatched("Both Node records in Introduction must have NodeAddr".to_string())),
             Some(node_addr) => node_addr.ip_addr(),
         };
         let second_agr = &agrs_ref[1];
         let second_ip = match second_agr.node_addr_opt.as_ref() {
-            None => return Err(Qualification::Unmatched),
+            None => return Err(Qualification::Unmatched("Both Node records in Introduction must have NodeAddr".to_string())),
             Some(node_addr) => node_addr.ip_addr(),
         };
         if first_ip == gossip_source.ip() {
@@ -917,7 +937,6 @@ impl IntroductionHandler {
     }
 
     fn verify_introducer(
-        db: &NeighborhoodDatabase,
         introducer: &AccessibleGossipRecord,
         root_node: &NodeRecord,
     ) -> Option<Qualification> {
@@ -947,16 +966,13 @@ impl IntroductionHandler {
     }
 
     fn verify_introducee(
-        db: &NeighborhoodDatabase,
+        _db: &NeighborhoodDatabase,
         introducer: &AccessibleGossipRecord,
         introducee: &AccessibleGossipRecord,
         gossip_source: SocketAddr,
     ) -> Option<Qualification> {
-        if db.root().half_neighbor_keys().contains(&introducee.inner.public_key) {
-            return Some(Qualification::Unmatched)
-        }
         let introducee_node_addr = match introducee.node_addr_opt.as_ref() {
-            None => return Some(Qualification::Unmatched),
+            None => return Some(Qualification::Unmatched("Introducee has no NodeAddr".to_string())),
             Some(node_addr) => node_addr,
         };
         if introducee_node_addr.ports().is_empty() {
@@ -986,6 +1002,20 @@ impl IntroductionHandler {
             )));
         }
         None
+    }
+
+    fn verify_both(
+        db: &NeighborhoodDatabase,
+        introducer: &AccessibleGossipRecord,
+        introducee: &AccessibleGossipRecord,
+    ) -> Option<Qualification> {
+        let half_neighbors = db.root().half_neighbor_keys();
+        if half_neighbors.contains(&introducee.inner.public_key) && half_neighbors.contains(&introducer.inner.public_key) {
+            Some(Qualification::Unmatched("Introducer and introducee are already our half-neighbors".to_string()))
+        }
+        else {
+            None
+        }
     }
 
     fn update_database(
@@ -1133,10 +1163,17 @@ impl GossipHandler for StandardGossipHandler {
         gossip_source: SocketAddr,
         neighborhood_metadata: NeighborhoodMetadata,
     ) -> Vec<GossipAcceptanceResult> {
+        // TODO:
+        // The first thing we should verify is the signature. If the signature fails, there should
+        // be an instant Malefactor ban.
+        // Next, we should look up the source Node in the database by gossip_source and validate all
+        // its immutable data (public key, earning wallet, maybe others). If any of that has changed,
+        // another Malefactor ban.
         let initial_neighborship_status =
             StandardGossipHandler::check_full_neighbor(database, gossip_source.ip());
         let gossip_source_agr = match agrs.iter().find(|agr| {
-            agr.node_addr_opt.as_ref().map(|na| na.ip_addr()) == Some(gossip_source.ip())
+            agr.inner.accepts_connections &&
+                (agr.node_addr_opt.as_ref().map(|na| na.ip_addr()) == Some(gossip_source.ip()))
         }) {
             Some(agr) => agr.clone(), // TODO: Why clone? Why not just reference?
             None => {
@@ -1265,7 +1302,7 @@ impl StandardGossipHandler {
                     patch.remove(current_node_key);
                     trace!(
                         self.logger,
-                        "While computing patch no AGR record found for public key {:?}",
+                        "While computing patch no Node record found for public key {:?}",
                         current_node_key
                     );
                     return;
@@ -1348,7 +1385,7 @@ impl StandardGossipHandler {
                 let ip_addr_opt = agr.node_addr_opt.map(|na| na.ip_addr());
                 bans.push(GossipAcceptanceResult::Ban(Malefactor::new(
                     Some(agr.inner.public_key.clone()),
-                    ip_addr_opt.clone(),
+                    ip_addr_opt,
                     Some(agr.inner.earning_wallet.clone()),
                     None,
                     format!(
@@ -1594,7 +1631,19 @@ impl GossipAcceptor for GossipAcceptorReal {
             .gossip_handlers
             .iter()
             .map(|h| (h.qualifies(database, &agrs, gossip_source), h.as_ref()))
-            .find(|pair| !matches!(pair, (Qualification::Unmatched, _)))
+            .map(|(qualification, handler_ref)| {
+                if let Qualification::Unmatched(msg) = &qualification {
+                    trace!(
+                        self.logger,
+                        "Gossip from {} did not qualify for {}: {}",
+                        gossip_source,
+                        handler_ref.type_name(),
+                        msg
+                    );
+                }
+                (qualification, handler_ref)
+            })
+            .find(|pair| !matches!(pair, (Qualification::Unmatched(_), _)))
             .expect("gossip_handlers should intercept everything");
         match qualification {
             Qualification::Matched => {
@@ -1611,7 +1660,7 @@ impl GossipAcceptor for GossipAcceptorReal {
                     neighborhood_metadata,
                 )
             }
-            Qualification::Unmatched => {
+            Qualification::Unmatched(_) => {
                 panic!("Nothing in gossip_handlers returned Matched or Malformed")
             }
             Qualification::Malformed(reason) => {
@@ -1884,25 +1933,25 @@ mod tests {
     fn proper_debut_of_non_accepting_node_with_populated_database_is_identified_and_handled() {
         let (gossip, new_node, gossip_source) = make_debut(2345, NeighborhoodModeLight::OriginateOnly.into());
         let root_node = make_node_record(1234, true);
-        let mut db = db_from_node(&root_node);
-        let neighbor_key = &db.add_node(make_node_record(3456, true)).unwrap();
-        db.add_arbitrary_full_neighbor(root_node.public_key(), neighbor_key);
-        let cryptde = CryptDENull::from(db.root().public_key(), TEST_DEFAULT_CHAIN);
+        let mut dest_db = db_from_node(&root_node);
+        let neighbor_key = &dest_db.add_node(make_node_record(3456, true)).unwrap();
+        dest_db.add_arbitrary_full_neighbor(root_node.public_key(), neighbor_key);
+        let cryptde = CryptDENull::from(dest_db.root().public_key(), TEST_DEFAULT_CHAIN);
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
         let subject = DebutHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
 
-        let qualifies_result = subject.qualifies(&db, agrs_vec.as_slice(), gossip_source.clone());
+        let qualifies_result = subject.qualifies(&dest_db, agrs_vec.as_slice(), gossip_source.clone());
         let handle_result = subject.handle(
             &cryptde,
-            &mut db,
+            &mut dest_db,
             agrs_vec,
             gossip_source,
             make_default_neighborhood_metadata(),
         );
 
         assert_eq!(Qualification::Matched, qualifies_result);
-        let introduction = GossipBuilder::new(&db)
-            .node(db.root().public_key(), true)
+        let introduction = GossipBuilder::new(&dest_db)
+            .node(dest_db.root().public_key(), true)
             .node(neighbor_key, true)
             .build();
         assert_eq!(
@@ -1913,6 +1962,12 @@ mod tests {
                 NodeAddr::from(&gossip_source),
             )],
         );
+        // Version of debuting Node in destination database should have NodeAddr
+        // even though it doesn't accept connections
+        let debuted_node = dest_db
+            .node_by_key(&new_node.public_key())
+            .unwrap();
+        assert_eq!(debuted_node.metadata.node_addr_opt, Some(NodeAddr::from(&gossip_source)));
     }
 
     #[test]
@@ -2022,11 +2077,11 @@ mod tests {
 
         let result = subject.qualifies(&db, agrs_vec.as_slice(), gossip_source);
 
-        assert_eq!(result, Qualification::Unmatched);
+        assert_eq!(result, Qualification::Unmatched("Node record already in database".to_string()));
     }
 
     #[test]
-    fn debut_of_already_connected_node_produces_introduction_because_we_no_longer_care_about_overconnection(
+    fn debut_of_already_connected_node_produces_debut_back_instead_of_introduction_to_prevent_overconnection(
     ) {
         let src_root = make_node_record(1234, true);
         let mut src_db = db_from_node(&src_root);
@@ -2056,53 +2111,18 @@ mod tests {
             make_default_neighborhood_metadata(),
         );
 
-        let expected_acceptance_gossip = GossipBuilder::new(&dest_db)
+        let expected_debut_back_gossip = GossipBuilder::new(&dest_db)
             .node(dest_root.public_key(), true)
-            .node(dest_neighbor.public_key(), true)
             .build();
         assert_eq!(
             result,
             vec![GossipAcceptanceResult::Reply(
-                expected_acceptance_gossip,
+                expected_debut_back_gossip,
                 src_root.public_key().clone(),
                 src_root.node_addr_opt().unwrap(),
             )]
         );
     }
-    //
-    // #[test]
-    // fn debut_of_already_connected_node_produces_accepted_result_instead_of_introduction_to_prevent_overconnection(
-    // ) {
-    //     let src_root = make_node_record(1234, true);
-    //     let mut src_db = db_from_node(&src_root);
-    //     let dest_root = make_node_record(2345, true);
-    //     let mut dest_db = db_from_node(&dest_root);
-    //     let dest_cryptde = CryptDENull::from(dest_root.public_key(), TEST_DEFAULT_CHAIN);
-    //     let common_neighbor = make_node_record(3456, true);
-    //     let dest_neighbor = make_node_record(4567, true);
-    //     src_db.add_node(common_neighbor.clone()).unwrap();
-    //     src_db.add_arbitrary_full_neighbor(src_root.public_key(), common_neighbor.public_key());
-    //     dest_db.add_node(common_neighbor.clone()).unwrap();
-    //     dest_db.add_arbitrary_full_neighbor(dest_root.public_key(), common_neighbor.public_key());
-    //     dest_db.add_node(dest_neighbor.clone()).unwrap();
-    //     dest_db.add_arbitrary_full_neighbor(dest_root.public_key(), dest_neighbor.public_key());
-    //     let agrs_vec: Vec<AccessibleGossipRecord> = GossipBuilder::new(&src_db)
-    //         .node(src_root.public_key(), true)
-    //         .build()
-    //         .try_into()
-    //         .unwrap();
-    //     let subject = DebutHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
-    //
-    //     let result = subject.handle(
-    //         &dest_cryptde,
-    //         &mut dest_db,
-    //         agrs_vec,
-    //         dest_root.node_addr_opt().clone().unwrap().into(),
-    //         make_default_neighborhood_metadata(),
-    //     );
-    //
-    //     assert_eq!(result, vec![GossipAcceptanceResult::Accepted]);
-    // }
 
     #[test]
     fn debut_is_rejected_when_validation_fails() {
@@ -2181,8 +2201,8 @@ mod tests {
     }
 
     #[test]
-    fn if_we_have_neighbors_but_none_qualify_for_introduction_accept_and_send_standard_gossip() {
-        let test_name = "if_we_have_neighbors_but_none_qualify_for_introduction_accept_and_send_standard_gossip";
+    fn if_we_have_neighbors_but_none_qualify_for_introduction_or_pass_then_debut_back() {
+        let test_name = "if_we_have_neighbors_but_none_qualify_for_introduction_or_pass_then_debut_back";
         let dest_root = make_node_record(1234, true);
         let root_node_cryptde = CryptDENull::from(&dest_root.public_key(), TEST_DEFAULT_CHAIN);
         let one_common_neighbor = make_node_record(4321, true); // can't introduce this one; debutant already knows it
@@ -2198,6 +2218,7 @@ mod tests {
             dest_root.public_key(),
             another_common_neighbor.public_key(),
         );
+        let original_version = dest_db.root().version();
 
         let mut debutant = make_node_record(4567, true);
         debutant.inner.neighbors.insert(one_common_neighbor.public_key().clone());
@@ -2216,11 +2237,20 @@ mod tests {
             )
             .unwrap();
 
-        match result {
-            GossipAcceptanceResult::Accepted => (),
-            x => panic!("Expected Accepted, got {:?}", x),
-        };
+        assert_eq!(result, GossipAcceptanceResult::Reply(
+            GossipBuilder::new(&dest_db)
+                .node(dest_db.root().public_key(), true)
+                .build(),
+            debutant.public_key().clone(),
+            debutant.node_addr_opt().expect("Debutant should have NodeAddr"),
+        ));
         assert!(dest_db.root().half_neighbor_keys().contains(debutant.public_key()));
+        assert_eq!(dest_db.root().version(), original_version + 1);
+        root_node_cryptde.verify_signature(
+            dest_db.root().signed_gossip(),
+            dest_db.root().signature(),
+            dest_db.root().public_key()
+        );
     }
 
     #[test]
@@ -2258,7 +2288,7 @@ mod tests {
     fn pass_with_node_that_does_not_accept_connections_is_rejected() {
         let root_node = make_node_record(1234, true); // irrelevant
         let mut db = db_from_node(&root_node); // irrelevant
-        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::OriginateOnly.into());
+        let (gossip, _pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::OriginateOnly.into());
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
         let subject = PassHandler::new();
 
@@ -2268,14 +2298,14 @@ mod tests {
             gossip_source,
         );
 
-        assert_eq!(result, Qualification::Unmatched);
+        assert_eq!(result, Qualification::Unmatched("Pass Node record always has a NodeAddr".to_string()));
     }
 
     #[test]
     fn pass_with_node_that_does_not_route_data_is_rejected() {
         let root_node = make_node_record(1234, true); // irrelevant
         let mut db = db_from_node(&root_node); // irrelevant
-        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::ConsumeOnly.into());
+        let (gossip, _pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::ConsumeOnly.into());
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
         let subject = PassHandler::new();
 
@@ -2285,7 +2315,7 @@ mod tests {
             gossip_source,
         );
 
-        assert_eq!(result, Qualification::Unmatched);
+        assert_eq!(result, Qualification::Unmatched("Pass Node record always has a NodeAddr".to_string()));
     }
 
     #[test]
@@ -2299,7 +2329,7 @@ mod tests {
 
         assert_eq!(
             result,
-            Qualification::Unmatched,
+            Qualification::Unmatched("Pass Node record always has a NodeAddr".to_string()),
         );
     }
 
@@ -2331,7 +2361,7 @@ mod tests {
 
         let result = subject.qualifies(&make_meaningless_db(), agrs_vec.as_slice(), gossip_source);
 
-        assert_eq!(Qualification::Unmatched, result);
+        assert_eq!(Qualification::Unmatched("Introduction has 2 Node records, not 1".to_string()), result);
     }
 
     #[test]
@@ -2354,7 +2384,7 @@ mod tests {
     }
 
     #[test]
-    fn introduction_is_unmatched_if_receiver_has_half_neighborship_with_introducee() {
+    fn introduction_is_matched_if_receiver_has_half_neighborship_with_introducee_but_not_introducer() {
         let (gossip, gossip_source) = make_introduction(2345, 3456);
         let introducer_in_target_db = make_node_record(2345, true);
         let introducee_in_target_db = make_node_record(3456, true);
@@ -2369,7 +2399,7 @@ mod tests {
 
         let result = subject.qualifies(&dest_db, agrs_vec.as_slice(), gossip_source);
 
-        assert_eq!(Qualification::Unmatched, result);
+        assert_eq!(result, Qualification::Matched);
     }
 
     #[test]
@@ -2389,7 +2419,7 @@ mod tests {
 
         let result = subject.qualifies(&dest_db, agrs_vec.as_slice(), gossip_source);
 
-        assert_eq!(Qualification::Unmatched, result);
+        assert_eq!(result, Qualification::Unmatched("Introducer and introducee are already our half-neighbors".to_string()));
     }
 
     #[test]
@@ -2404,7 +2434,7 @@ mod tests {
 
         let result = subject.qualifies(&dest_db, agrs_vec.as_slice(), gossip_source);
 
-        assert_eq!(Qualification::Unmatched, result);
+        assert_eq!(Qualification::Unmatched("Both Node records in Introduction must have NodeAddr".to_string()), result);
     }
 
     #[test]
@@ -2438,7 +2468,7 @@ mod tests {
 
         let result = subject.qualifies(&dest_db, agrs_vec.as_slice(), gossip_source);
 
-        assert_eq!(Qualification::Unmatched, result);
+        assert_eq!(Qualification::Unmatched("Both Node records in Introduction must have NodeAddr".to_string()), result);
     }
 
     #[test]
@@ -3301,7 +3331,7 @@ mod tests {
         .collect::<HashSet<PublicKey>>();
         assert_eq!(patch, expected_hashset);
         TestLogHandler::new().exists_log_matching(&format!(
-            "TRACE: {}: While computing patch no AGR record found for public key {:?}",
+            "TRACE: {}: While computing patch no Node record found for public key {:?}",
             test_name,
             node_x.public_key()
         ));
@@ -3582,7 +3612,6 @@ mod tests {
         ]);
         let recording = recording_arc.lock().unwrap();
         assert_eq!(recording.len(), 0);
-        let tlh = TestLogHandler::new();
     }
 
     #[test]
@@ -3625,7 +3654,7 @@ mod tests {
     }
 
     #[test]
-    fn standard_gossip_that_does_not_describe_gossip_source_is_rejected() {
+    fn standard_gossip_from_node_that_accepts_connections_but_does_not_describe_gossip_source_is_rejected() {
         /*
           Destination Node ==>
             S---D
@@ -3677,6 +3706,64 @@ mod tests {
             )),]
         );
         TestLogHandler::new().exists_log_containing(&format!("WARN: {}: {}", test_name, message));
+    }
+
+    #[test]
+    fn standard_gossip_that_does_not_describe_gossip_source_is_rejected() {
+        /*
+          Destination Node ==>
+            S---D
+
+          Source Node ==>
+           S---D
+
+          The source node(S) will send Gossip containing no IP address. However, we can know its
+          IP address from the network stack, and we'll also know its IP address from when it
+          debuted. Therefore, we can know to ban it.
+        */
+        let test_name = "standard_gossip_that_does_not_describe_gossip_source_is_rejected";
+        let mut src_root = make_node_record(1234, true);
+        let src_root_with_node_addr = src_root.clone();
+        src_root.metadata.node_addr_opt = None;
+        src_root.inner.accepts_connections = false;
+        src_root.resign();
+        let dest_root = make_node_record(2345, true);
+        let mut src_db = db_from_node(&src_root);
+        let mut dest_db = db_from_node(&dest_root);
+        dest_db.add_node(src_root_with_node_addr).unwrap();
+        dest_db.add_arbitrary_full_neighbor(dest_root.public_key(), src_root.public_key());
+        src_db.add_node(dest_db.root().clone()).unwrap();
+        src_db.add_arbitrary_full_neighbor(src_root.public_key(), dest_root.public_key());
+        let subject =
+            StandardGossipHandler::new(&RatePackLimits::test_default(), Logger::new(test_name));
+        let cryptde = CryptDENull::from(dest_db.root().public_key(), TEST_DEFAULT_CHAIN);
+        let gossip = GossipBuilder::new(&src_db)
+            .node(src_root.public_key(), false)
+            .build();
+        let (cpm_recipient, _) = make_cpm_recipient();
+        let mut neighborhood_metadata = make_default_neighborhood_metadata();
+        neighborhood_metadata.cpm_recipient = cpm_recipient;
+        // A SocketAddr that doesn't match anything in the Standard Gossip
+        let malefactor_socket_addr = SocketAddr::from_str("3.4.5.6:3456").unwrap();
+
+        let handle_result = subject.handle(
+            &cryptde,
+            &mut dest_db,
+            gossip.try_into().unwrap(),
+            malefactor_socket_addr,
+            neighborhood_metadata,
+        );
+
+        assert_eq!(
+            handle_result,
+            vec![GossipAcceptanceResult::Ban(Malefactor::new(
+                None,
+                Some(malefactor_socket_addr.ip()),
+                None,
+                None,
+                "Node at 3.4.5.6 sent Standard gossip without a record describing itself".to_string()
+            ))]
+        );
     }
 
     #[test]
@@ -4511,10 +4598,13 @@ mod tests {
     #[test]
     fn pass_is_properly_handled() {
         // This test makes sure GossipAcceptor works correctly
+        init_test_logging();
+        let test_name = "pass_is_properly_handled";
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
-        let subject = make_subject(GA_CRYPTDE_PAIR.main.as_ref());
+        let mut subject = make_subject(GA_CRYPTDE_PAIR.main.as_ref());
+        subject.logger = Logger::new(test_name);
 
         let result = subject.handle(
             &mut db,
@@ -4535,6 +4625,13 @@ mod tests {
             )]
         );
         assert_eq!(db.keys().len(), 1);
+        TestLogHandler::new().exists_log_containing(format!(
+            "TRACE: {}: Gossip from {} did not qualify for {}: {}",
+            test_name,
+            gossip_source,
+            "DebutHandler",
+            "Node record is not Gossip source"
+        ).as_str());
     }
 
     #[test]
@@ -5125,7 +5222,8 @@ mod tests {
             .build();
         let subject = make_subject(GA_CRYPTDE_PAIR.main.as_ref());
         let original_dest_db = dest_db.clone();
-        let before = time_t_timestamp();
+        // Ww shouldn't be changing anything, so timestamps shouldn't matter
+        let before = time_t_timestamp() - 3600;
 
         let result = subject.handle(
             &mut dest_db,
@@ -5134,7 +5232,7 @@ mod tests {
             make_default_neighborhood_metadata(),
         );
 
-        let after = time_t_timestamp();
+        let after = time_t_timestamp() + 3600;
         assert_eq!(result, vec![]);
         assert_node_records_eq(
             dest_db.node_by_key(dest_root.public_key()).unwrap(),
@@ -5481,29 +5579,12 @@ mod tests {
     }
 
     #[test]
-    fn should_not_make_another_introduction_says_false_for_1_routing_neighbor() {
+    fn should_not_make_another_introduction_says_true_for_1_routing_neighbor() {
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let neighbor = make_node_record(2345, true);
         db.add_node(neighbor.clone()).unwrap();
         db.add_arbitrary_full_neighbor(&root_node.public_key(), &neighbor.public_key());
-        let agr = AccessibleGossipRecord::from(db.root());
-
-        let result = DebutHandler::should_not_make_another_introduction(&db, &agr);
-
-        assert_eq!(result, false);
-    }
-
-    #[test]
-    fn should_not_make_another_introduction_says_true_for_2_routing_neighbors() {
-        let root_node = make_node_record(1234, true);
-        let mut db = db_from_node(&root_node);
-        let neighbor_1 = make_node_record(2345, true);
-        db.add_node(neighbor_1.clone()).unwrap();
-        db.add_arbitrary_full_neighbor(&root_node.public_key(), &neighbor_1.public_key());
-        let neighbor_2 = make_node_record(3456, true);
-        db.add_node(neighbor_2.clone()).unwrap();
-        db.add_arbitrary_full_neighbor(&root_node.public_key(), &neighbor_2.public_key());
         let agr = AccessibleGossipRecord::from(db.root());
 
         let result = DebutHandler::should_not_make_another_introduction(&db, &agr);

--- a/node/src/neighborhood/gossip_acceptor.rs
+++ b/node/src/neighborhood/gossip_acceptor.rs
@@ -38,13 +38,6 @@ pub enum GossipAcceptanceResult {
     // The incoming Gossip was proper, and we tried to accept it, but couldn't.
     Failed(GossipFailure_0v1, PublicKey, NodeAddr),
     // Gossip was ignored because it was evil: ban the sender of the Gossip as a malefactor.
-    // TODO: This is wrong. We don't always want to ban the sender; sometimes we'll want to ban
-    // some other Node in the Gossip. And we can't refer to that Node by public key and then look
-    // it up later, because if we're banning it we've probably already pulled it out of the
-    // neighborhood database. This variant needs to be able to contain information about at least:
-    // public key, IP address, and earning wallet address. Possibly more. Since this will be
-    // a collection of Options, perhaps the Options should be collected in a struct, which would
-    // be an argument to the Ban variant.
     Ban(Malefactor),
 }
 
@@ -256,8 +249,7 @@ impl GossipHandler for DebutHandler {
 
 enum IntroductionAttempt {
     Success(Gossip_0v1, PublicKey, NodeAddr),
-    YoungNetworkFailure,
-    CommonNeighborFailure,
+    Failure,
 }
 
 impl DebutHandler {
@@ -278,10 +270,9 @@ impl DebutHandler {
         let qualified_neighbors: Vec<&PublicKey> = neighbor_vec
             .into_iter()
             .filter(|k| {
-                database
-                    .node_by_key(*k)
-                    .expect("Node disappeared")
-                    .accepts_connections()
+                let node = database.node_by_key(*k)
+                    .expect("Node disappeared");
+                node.accepts_connections() && node.routes_data()
             })
             .skip_while(|k| database.gossip_target_degree(*k) <= 2)
             .collect();
@@ -309,7 +300,6 @@ impl DebutHandler {
             }
         }
     }
-
 
     fn try_accept_debut(
         &self,
@@ -347,7 +337,7 @@ impl DebutHandler {
                 root_mut.increment_version();
                 root_mut.regenerate_signed_gossip(cryptde);
                 trace!(self.logger, "Current database: {}", database.to_dot_graph());
-                if Self::should_not_make_another_introduction(debuting_agr) {
+                if Self::should_not_make_another_introduction(&database, debuting_agr) {
                     let ip_addr_str = match &debuting_agr.node_addr_opt {
                         Some(node_addr) => node_addr.ip_addr().to_string(),
                         None => "?.?.?.?".to_string(),
@@ -365,7 +355,7 @@ impl DebutHandler {
                                 target_node_addr,
                             ))
                         },
-                        IntroductionAttempt::YoungNetworkFailure => {
+                        IntroductionAttempt::Failure => {
                             debug!(
                                 self.logger,
                                 "DebutHandler has no one to introduce, but is debuting back to {} at {}",
@@ -391,18 +381,6 @@ impl DebutHandler {
                                     .expect("Debut gossip always has an IP")
                                     .clone(),
                             ))
-                        },
-                        IntroductionAttempt::CommonNeighborFailure => {
-                            debug!(
-                                self.logger,
-                                "DebutHandler shares too many neighbors to be able to introduce a Node; so sending Standard Gossip",
-                            );
-                            trace!(
-                                self.logger,
-                                "DebutHandler database state: {}",
-                                &database.to_dot_graph(),
-                            );
-                            Ok(GossipAcceptanceResult::Accepted)
                         }
                     }
                 }
@@ -474,11 +452,8 @@ impl DebutHandler {
                 debut_node_addr,
             )
         }
-        else if database.root().full_neighbor_keys(database).is_empty() {
-            IntroductionAttempt::YoungNetworkFailure
-        }
         else {
-            IntroductionAttempt::CommonNeighborFailure
+            IntroductionAttempt::Failure
         }
     }
 
@@ -503,10 +478,8 @@ impl DebutHandler {
                 .full_neighbor_keys(database)
                 .into_iter()
                 .filter(|k| {
-                    database
-                        .node_by_key(*k)
-                        .expect("Node disappeared")
-                        .accepts_connections()
+                    let candidate = database.node_by_key(*k).expect("Node disappeared");
+                    candidate.accepts_connections() && candidate.routes_data()
                 })
                 .collect(),
             database,
@@ -560,9 +533,14 @@ impl DebutHandler {
         keys
     }
 
-    fn should_not_make_another_introduction(_debuting_agr: &AccessibleGossipRecord) -> bool {
-        false
-        // !debuting_agr.inner.neighbors.is_empty()
+    fn should_not_make_another_introduction(db: &NeighborhoodDatabase, debuting_agr: &AccessibleGossipRecord) -> bool {
+        let routing_neighbors = debuting_agr.inner.neighbors.iter().filter(|pk| {
+            match db.node_by_key(pk) {
+                Some(node) => node.inner.routes_data,
+                None => false,
+            }
+        });
+        routing_neighbors.count() >= 2 // 2 is arbitrary choice
     }
 
     fn make_pass_gossip(database: &NeighborhoodDatabase, pass_target: &PublicKey) -> Gossip_0v1 {
@@ -598,10 +576,7 @@ impl GossipHandler for PassHandler {
             return Qualification::Unmatched;
         }
         match &agrs[0].node_addr_opt {
-            None => Qualification::Malformed(format!(
-                "Pass from {} to {} did not contain NodeAddr",
-                gossip_source, agrs[0].inner.public_key
-            )),
+            None => Qualification::Unmatched,
             Some(node_addr) => {
                 if node_addr.ports().is_empty() {
                     Qualification::Malformed(format!(
@@ -714,9 +689,8 @@ impl NamedType for IntroductionHandler {
 impl GossipHandler for IntroductionHandler {
     // An Introduction must contain two AGRs, one representing the introducer and one representing
     // the introducee. Both records must provide their IP addresses. One of the IP addresses must
-    // match the gossip_source. The other record's IP address must not match the gossip_source. The
-    // record whose IP address matches the gossip source must not be targeted by a half
-    // neighborship from this Node.
+    // match the gossip_source. The other record's IP address must not match the gossip_source.
+    // Neither of the two records can be targeted by a half neighborship from this Node.
     fn qualifies(
         &self,
         database: &NeighborhoodDatabase,
@@ -732,13 +706,13 @@ impl GossipHandler for IntroductionHandler {
                 Ok(true) => (&agrs[0], &agrs[1]),
                 Ok(false) => (&agrs[1], &agrs[0]),
             };
-        if let Some(qual) = Self::verify_introducer(introducer, database.root()) {
+        if let Some(qual) = Self::verify_introducer(database, introducer, database.root()) {
             return qual;
         };
-        if let Some(qual) = Self::verify_introducee(introducer, introducee, gossip_source) {
+        if let Some(qual) = Self::verify_introducee(database, introducer, introducee, gossip_source) {
             return qual;
         };
-        Self::verify_both(database, introducer, introducee)
+        Qualification::Matched
     }
 
     fn handle(
@@ -754,6 +728,7 @@ impl GossipHandler for IntroductionHandler {
         }
         let (introducer, introducee) = Self::identify_players(agrs, gossip_source)
             .expect("Introduction not properly qualified");
+        // TODO: Should be _opt. Also, think about some outboard methods.
         let mut introducer_ban_message = GossipAcceptorReal::validate_new_version(
             &introducer,
             format!(
@@ -764,6 +739,7 @@ impl GossipHandler for IntroductionHandler {
             &self.logger,
         )
         .err();
+        // TODO: Should be _opt
         let introducee_ban_message = GossipAcceptorReal::validate_new_version(
             &introducee,
             format!(
@@ -779,6 +755,7 @@ impl GossipHandler for IntroductionHandler {
             &self.logger,
         )
         .err();
+        // TODO: We shouldn't have to extract all this unless we're doing a ban.
         let introducer_key = introducer.inner.public_key.clone();
         let introducer_wallet = introducer.inner.earning_wallet.clone();
         let introducer_ip_addr = introducer
@@ -940,6 +917,7 @@ impl IntroductionHandler {
     }
 
     fn verify_introducer(
+        db: &NeighborhoodDatabase,
         introducer: &AccessibleGossipRecord,
         root_node: &NodeRecord,
     ) -> Option<Qualification> {
@@ -969,10 +947,14 @@ impl IntroductionHandler {
     }
 
     fn verify_introducee(
+        db: &NeighborhoodDatabase,
         introducer: &AccessibleGossipRecord,
         introducee: &AccessibleGossipRecord,
         gossip_source: SocketAddr,
     ) -> Option<Qualification> {
+        if db.root().half_neighbor_keys().contains(&introducee.inner.public_key) {
+            return Some(Qualification::Unmatched)
+        }
         let introducee_node_addr = match introducee.node_addr_opt.as_ref() {
             None => return Some(Qualification::Unmatched),
             Some(node_addr) => node_addr,
@@ -1004,21 +986,6 @@ impl IntroductionHandler {
             )));
         }
         None
-    }
-
-    fn verify_both(
-        database: &NeighborhoodDatabase,
-        introducer: &AccessibleGossipRecord,
-        introducee: &AccessibleGossipRecord,
-    ) -> Qualification {
-        let root = database.root();
-        let neighbors = &root.inner.neighbors;
-        if neighbors.contains(&introducer.inner.public_key) && neighbors.contains(&introducee.inner.public_key) {
-            Qualification::Unmatched
-        }
-        else {
-            Qualification::Matched
-        }
     }
 
     fn update_database(
@@ -1171,7 +1138,7 @@ impl GossipHandler for StandardGossipHandler {
         let gossip_source_agr = match agrs.iter().find(|agr| {
             agr.node_addr_opt.as_ref().map(|na| na.ip_addr()) == Some(gossip_source.ip())
         }) {
-            Some(agr) => agr.clone(),
+            Some(agr) => agr.clone(), // TODO: Why clone? Why not just reference?
             None => {
                 let message = format!(
                     "Node at {} sent Standard gossip without a record describing itself",
@@ -1210,6 +1177,7 @@ impl GossipHandler for StandardGossipHandler {
         db_changed |= !obsolete_agrs.is_empty();
         self.update_obsolete_nodes(database, obsolete_agrs);
 
+        // TODO: I don't think we need || db_changed at the end of the next statement
         db_changed |=
             self.add_src_node_as_half_neighbor(cryptde, database, gossip_source) || db_changed;
         let final_neighborship_status =
@@ -1237,6 +1205,7 @@ impl GossipHandler for StandardGossipHandler {
             );
             vec![]
         };
+        // TODO: Probably don't need the .is_empty() check
         if !malefactor_bans.is_empty() {
             response.extend(malefactor_bans);
         }
@@ -1375,7 +1344,22 @@ impl StandardGossipHandler {
             let (mut valid_agrs, mut bans) = so_far;
             if &agr.inner.public_key == database.root_key() {
                 // Shouldn't ever happen; but an evil Node could try it
-                valid_agrs.push(agr)
+                // valid_agrs.push(agr);
+                let ip_addr_opt = agr.node_addr_opt.map(|na| na.ip_addr());
+                bans.push(GossipAcceptanceResult::Ban(Malefactor::new(
+                    Some(agr.inner.public_key.clone()),
+                    ip_addr_opt.clone(),
+                    Some(agr.inner.earning_wallet.clone()),
+                    None,
+                    format!(
+                        "Node {} at {} sent Standard gossip that contained a record claiming our own public key",
+                        agr.inner.public_key,
+                        match ip_addr_opt {
+                            Some(ip) => ip.to_string(),
+                            None => "?.?.?.?".to_string(),
+                        }
+                    )
+                )));
             }
             else if (agr.node_addr_opt.as_ref().map(|addr| addr.ip_addr()) != Some(gossip_source_ip)) && !next_door_neighbor_keys.contains(&&agr.inner.public_key) && agr.node_addr_opt.is_some() {
                 bans.push(GossipAcceptanceResult::Ban(Malefactor::new(
@@ -1385,9 +1369,9 @@ impl StandardGossipHandler {
                     None,
                     format!(
                         "Node {} at {:?} sent Standard gossip that contained an IP address for victim Node {} that we should not have known",
-                            gossip_source_agr.inner.public_key,
-                            gossip_source_ip,
-                            agr.inner.public_key,
+                        gossip_source_agr.inner.public_key,
+                        gossip_source_ip,
+                        agr.inner.public_key,
                     ),
                 )));
             }
@@ -1723,17 +1707,20 @@ impl GossipAcceptorReal {
         rate_pack_limits: &RatePackLimits,
         logger: &Logger,
     ) -> Result<(), String> {
-        match rate_pack_limits.analyze(&agr.inner.rate_pack) {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                let message = format!(
-                    "{} rejected due to rate pack limit violation: {:?}",
-                    agr_description, e
-                );
-                warning!(logger, "{}", message.as_str());
-                Err(message)
+        if agr.inner.routes_data {
+            return match rate_pack_limits.analyze(&agr.inner.rate_pack) {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    let message = format!(
+                        "{} rejected due to rate pack limit violation: {:?}",
+                        agr_description, e
+                    );
+                    warning!(logger, "{}", message.as_str());
+                    Err(message)
+                }
             }
         }
+        Ok(())
     }
 }
 
@@ -1779,9 +1766,7 @@ mod tests {
         UNREACHABLE_COUNTRY_PENALTY,
     };
     use crate::sub_lib::cryptde_null::CryptDENull;
-    use crate::sub_lib::neighborhood::{
-        ConnectionProgressEvent, ConnectionProgressMessage, RatePack,
-    };
+    use crate::sub_lib::neighborhood::{ConnectionProgressEvent, ConnectionProgressMessage, RatePack, DEFAULT_RATE_PACK, ZERO_RATE_PACK};
     use crate::sub_lib::utils::time_t_timestamp;
     use crate::test_utils::neighborhood_test_utils::{
         db_from_node, gossip_about_nodes_from_database, linearly_connect_nodes,
@@ -1803,6 +1788,7 @@ mod tests {
     use std::ops::{Add, Sub};
     use std::str::FromStr;
     use std::time::Duration;
+    use masq_lib::utils::NeighborhoodModeLight;
 
     lazy_static! {
         static ref GA_CRYPTDE_PAIR: CryptDEPair = CryptDEPair::null();
@@ -1815,11 +1801,29 @@ mod tests {
     }
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    enum Mode {
-        Standard,
-        OriginateOnly,
-        // GossipAcceptor doesn't care about ConsumeOnly; that's routing, not Gossip
-        // ZeroHop is decentralized and should never appear in GossipAcceptor tests
+    struct Mode {
+        pub accepts_connections: bool,
+        pub routes_data: bool,
+    }
+
+    impl Mode {
+        pub fn new(accepts_connections: bool, routes_data: bool) -> Self {
+            Self {
+                accepts_connections,
+                routes_data,
+            }
+        }
+    }
+
+    impl From<NeighborhoodModeLight> for Mode {
+        fn from(neighborhood_mode: NeighborhoodModeLight) -> Self {
+            match neighborhood_mode {
+                NeighborhoodModeLight::Standard => Mode::new(true, true),
+                NeighborhoodModeLight::OriginateOnly => Mode::new(false, true),
+                NeighborhoodModeLight::ConsumeOnly => Mode::new(false, false),
+                NeighborhoodModeLight::ZeroHop => unimplemented!("ZeroHop should not be used in GossipAcceptor tests"),
+            }
+        }
     }
 
     fn make_default_neighborhood_metadata() -> NeighborhoodMetadata {
@@ -1842,7 +1846,7 @@ mod tests {
 
     #[test]
     fn proper_debut_of_accepting_node_with_populated_database_is_identified_and_handled() {
-        let (gossip, new_node, gossip_source_opt) = make_debut(2345, Mode::Standard);
+        let (gossip, new_node, gossip_source_opt) = make_debut(2345, NeighborhoodModeLight::Standard.into());
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let neighbor_key = &db.add_node(make_node_record(3456, true)).unwrap();
@@ -1878,7 +1882,7 @@ mod tests {
 
     #[test]
     fn proper_debut_of_non_accepting_node_with_populated_database_is_identified_and_handled() {
-        let (gossip, new_node, gossip_source) = make_debut(2345, Mode::OriginateOnly);
+        let (gossip, new_node, gossip_source) = make_debut(2345, NeighborhoodModeLight::OriginateOnly.into());
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let neighbor_key = &db.add_node(make_node_record(3456, true)).unwrap();
@@ -1952,7 +1956,7 @@ mod tests {
 
     #[test]
     fn debut_with_node_addr_not_accepting_connections_is_rejected() {
-        let (mut gossip, _j, gossip_source) = make_debut(2345, Mode::OriginateOnly);
+        let (mut gossip, _j, gossip_source) = make_debut(2345, NeighborhoodModeLight::OriginateOnly.into());
         let subject = DebutHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
         gossip.node_records[0].node_addr_opt = Some(NodeAddr::new(
             &IpAddr::from_str("1.2.3.4").unwrap(),
@@ -1965,14 +1969,14 @@ mod tests {
         assert_eq!(
             result,
             Qualification::Malformed(
-                "Debut from 200.200.200.200:2000 for AgMEBQ does not accept connections, yet contained NodeAddr".to_string()
+                "Debut from 2.3.4.5:2345 for AgMEBQ does not accept connections, yet contained NodeAddr".to_string()
             ),
         );
     }
 
     #[test]
     fn debut_without_node_addr_accepting_connections_is_rejected() {
-        let (mut gossip, _j, gossip_source) = make_debut(2345, Mode::Standard);
+        let (mut gossip, _j, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into());
         gossip.node_records[0].node_addr_opt = None;
         let subject = DebutHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
@@ -1989,7 +1993,7 @@ mod tests {
 
     #[test]
     fn debut_without_node_addr_ports_accepting_connections_is_rejected() {
-        let (mut gossip, _, gossip_source) = make_debut(2345, Mode::Standard);
+        let (mut gossip, _, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into());
         gossip.node_records[0].node_addr_opt =
             Some(NodeAddr::new(&IpAddr::from_str("1.2.3.4").unwrap(), &[]));
         let subject = DebutHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
@@ -2007,7 +2011,7 @@ mod tests {
 
     #[test]
     fn apparent_debut_with_node_already_in_database_is_unmatched() {
-        let (gossip, new_node, gossip_source) = make_debut(2345, Mode::Standard);
+        let (gossip, new_node, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into());
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let neighbor_key = &db.add_node(make_node_record(3456, true)).unwrap();
@@ -2221,7 +2225,7 @@ mod tests {
 
     #[test]
     fn proper_pass_is_identified_and_processed() {
-        let (gossip, pass_target, gossip_source) = make_pass(2345, Mode::Standard);
+        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
         let subject = PassHandler::new();
         let mut dest_db = make_meaningless_db();
         let cryptde = CryptDENull::from(dest_db.root().public_key(), TEST_DEFAULT_CHAIN);
@@ -2250,10 +2254,28 @@ mod tests {
         );
     }
 
+    #[test]
     fn pass_with_node_that_does_not_accept_connections_is_rejected() {
         let root_node = make_node_record(1234, true); // irrelevant
         let mut db = db_from_node(&root_node); // irrelevant
-        let (mut gossip, pass_target, gossip_source) = make_pass(2345, Mode::OriginateOnly);
+        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::OriginateOnly.into());
+        let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
+        let subject = PassHandler::new();
+
+        let result = subject.qualifies(
+            &mut db,
+            agrs_vec.as_slice(),
+            gossip_source,
+        );
+
+        assert_eq!(result, Qualification::Unmatched);
+    }
+
+    #[test]
+    fn pass_with_node_that_does_not_route_data_is_rejected() {
+        let root_node = make_node_record(1234, true); // irrelevant
+        let mut db = db_from_node(&root_node); // irrelevant
+        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::ConsumeOnly.into());
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
         let subject = PassHandler::new();
 
@@ -2268,7 +2290,7 @@ mod tests {
 
     #[test]
     fn pass_without_node_addr_is_rejected() {
-        let (mut gossip, _, gossip_source) = make_pass(2345, Mode::Standard);
+        let (mut gossip, _, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
         gossip.node_records[0].node_addr_opt = None;
         let subject = PassHandler::new();
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
@@ -2276,16 +2298,14 @@ mod tests {
         let result = subject.qualifies(&make_meaningless_db(), agrs_vec.as_slice(), gossip_source);
 
         assert_eq!(
-            Qualification::Malformed(
-                "Pass from 200.200.200.200:2000 to AgMEBQ did not contain NodeAddr".to_string()
-            ),
-            result
+            result,
+            Qualification::Unmatched,
         );
     }
 
     #[test]
     fn pass_without_node_addr_ports_is_rejected() {
-        let (mut gossip, _, gossip_source) = make_pass(2345, Mode::Standard);
+        let (mut gossip, _, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
         gossip.node_records[0].node_addr_opt =
             Some(NodeAddr::new(&IpAddr::from_str("1.2.3.4").unwrap(), &[]));
         let subject = PassHandler::new();
@@ -2294,17 +2314,17 @@ mod tests {
         let result = subject.qualifies(&make_meaningless_db(), agrs_vec.as_slice(), gossip_source);
 
         assert_eq!(
+            result,
             Qualification::Malformed(
                 "Pass from 200.200.200.200:2000 to AgMEBQ at 1.2.3.4 contained NodeAddr with no ports"
                     .to_string()
             ),
-            result
         );
     }
 
     #[test]
     fn gossip_containing_other_than_two_records_is_not_an_introduction() {
-        let (gossip, _, gossip_source) = make_debut(2345, Mode::Standard);
+        let (gossip, _, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into());
         let subject =
             IntroductionHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
@@ -2315,7 +2335,7 @@ mod tests {
     }
 
     #[test]
-    fn introduction_is_matched_if_receiver_has_half_neighborship_with_introducer_but_not_introducee() {
+    fn introduction_is_still_matched_even_if_receiver_has_half_neighborship_with_introducer() {
         let (gossip, gossip_source) = make_introduction(2345, 3456);
         let introducer_in_target_db = make_node_record(2345, true);
         let introducee_in_target_db = make_node_record(3456, true);
@@ -2330,11 +2350,11 @@ mod tests {
 
         let result = subject.qualifies(&dest_db, agrs_vec.as_slice(), gossip_source);
 
-        assert_eq!(Qualification::Matched, result);
+        assert_eq!(result, Qualification::Matched);
     }
 
     #[test]
-    fn introduction_is_matched_if_receiver_has_half_neighborship_with_introducee_but_not_introducer() {
+    fn introduction_is_unmatched_if_receiver_has_half_neighborship_with_introducee() {
         let (gossip, gossip_source) = make_introduction(2345, 3456);
         let introducer_in_target_db = make_node_record(2345, true);
         let introducee_in_target_db = make_node_record(3456, true);
@@ -2349,7 +2369,7 @@ mod tests {
 
         let result = subject.qualifies(&dest_db, agrs_vec.as_slice(), gossip_source);
 
-        assert_eq!(Qualification::Matched, result);
+        assert_eq!(Qualification::Unmatched, result);
     }
 
     #[test]
@@ -2525,59 +2545,6 @@ mod tests {
                 introducer_key
             )),
             result
-        );
-    }
-
-    #[test]
-    fn introduction_that_tries_to_change_immutable_characteristics_of_introducer_is_suspicious() {
-        let (gossip, gossip_source) = make_introduction(2345, 3456);
-        let dest_root = make_node_record(7878, true);
-        let mut dest_db = db_from_node(&dest_root);
-        let cryptde = CryptDENull::from(dest_db.root().public_key(), TEST_DEFAULT_CHAIN);
-        let subject =
-            IntroductionHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
-        let agrs: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
-        let introducer_key = &agrs[0].inner.public_key;
-        dest_db.add_node(NodeRecord::from(&agrs[0])).unwrap();
-        dest_db
-            .node_by_key_mut(introducer_key)
-            .unwrap()
-            .set_version(0);
-        dest_db
-            .node_by_key_mut(introducer_key)
-            .unwrap()
-            .force_node_addr(&NodeAddr::from(
-                &SocketAddr::from_str("4.5.6.7:4567").unwrap(),
-            ));
-        dest_db.resign_node(introducer_key);
-        let introducer_before_gossip = dest_db.node_by_key(introducer_key).unwrap().clone();
-        let before = time_t_timestamp();
-
-        let qualifies_result = subject.qualifies(&dest_db, &agrs, gossip_source);
-        let handle_result = subject.handle(
-            &cryptde,
-            &mut dest_db,
-            agrs.clone(),
-            gossip_source,
-            make_default_neighborhood_metadata(),
-        );
-
-        let after = time_t_timestamp();
-        assert_eq!(qualifies_result, Qualification::Matched);
-        // Again: we don't trust the introducer, so we don't accept the introducee this time.
-        // But we don't ban him, in case he's introduced later by a good guy.
-        assert_eq!(handle_result, vec![GossipAcceptanceResult::Ban(Malefactor::new(
-            Some(agrs[0].inner.public_key.clone()),
-            Some(agrs[0].node_addr_opt.as_ref().unwrap().ip_addr()),
-            Some(agrs[0].inner.earning_wallet.clone()),
-            None,
-            format!("Introducer {} tried changing immutable characteristic: Updating a NodeRecord must not change its node_addr_opt: 4.5.6.7:4567 -> 2.3.4.5:2345", introducer_key)
-        ))]);
-        assert_node_records_eq(
-            dest_db.node_by_key_mut(introducer_key).unwrap(),
-            &introducer_before_gossip,
-            before,
-            after,
         );
     }
 
@@ -3600,9 +3567,22 @@ mod tests {
 
         System::current().stop();
         assert_eq!(system.run(), 0);
-        assert_eq!(result, vec![GossipAcceptanceResult::Accepted]);
+        assert_eq!(result, vec![
+            GossipAcceptanceResult::Accepted,
+            GossipAcceptanceResult::Ban(Malefactor::new(
+                Some(root_node.public_key().clone()),
+                Some(root_node.node_addr_opt().unwrap().ip_addr()),
+                Some(root_node.earning_wallet()),
+                None,
+                format!("Node {} at {} sent Standard gossip that contained a record claiming our own public key",
+                    root_node.public_key(),
+                    root_node.node_addr_opt().unwrap().ip_addr()
+                )
+            ))
+        ]);
         let recording = recording_arc.lock().unwrap();
         assert_eq!(recording.len(), 0);
+        let tlh = TestLogHandler::new();
     }
 
     #[test]
@@ -3803,10 +3783,10 @@ mod tests {
         let subject = make_subject(GA_CRYPTDE_PAIR.main.as_ref());
         let reject_handler = subject.gossip_handlers.last().unwrap();
         let db = make_meaningless_db();
-        let (debut, _, debut_gossip_source) = make_debut(1234, Mode::Standard);
-        let (pass, _, pass_gossip_source) = make_pass(2345, Mode::Standard);
+        let (debut, _, debut_gossip_source) = make_debut(1234, NeighborhoodModeLight::Standard.into());
+        let (pass, _, pass_gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
         let (introduction, introduction_gossip_source) = make_introduction(3456, 4567);
-        let (standard_gossip, _, standard_gossip_source) = make_debut(9898, Mode::Standard);
+        let (standard_gossip, _, standard_gossip_source) = make_debut(9898, NeighborhoodModeLight::Standard.into());
         let debut_vec: Vec<AccessibleGossipRecord> = debut.try_into().unwrap();
         let pass_vec: Vec<AccessibleGossipRecord> = pass.try_into().unwrap();
         let introduction_vec: Vec<AccessibleGossipRecord> = introduction.try_into().unwrap();
@@ -3887,7 +3867,7 @@ mod tests {
         let mut root_node = make_node_record(1234, true);
         let root_node_cryptde = CryptDENull::from(&root_node.public_key(), TEST_DEFAULT_CHAIN);
         let mut source_db = db_from_node(&root_node);
-        let (gossip, mut debut_node, gossip_source) = make_debut(2345, Mode::Standard); //debut node is FR
+        let (gossip, mut debut_node, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into()); //debut node is FR
         let mut expected_source_db = db_from_node(&root_node);
         expected_source_db
             .add_arbitrary_half_neighbor(root_node.public_key(), debut_node.public_key());
@@ -3953,7 +3933,7 @@ mod tests {
             .unwrap()
             .resign();
         dest_db.node_by_key_mut(existing_node_key).unwrap().resign();
-        let (gossip, mut debut_node, gossip_source) = make_debut(2345, Mode::Standard);
+        let (gossip, mut debut_node, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into());
         let subject = make_subject(&root_node_cryptde);
         let before = time_t_timestamp();
 
@@ -4023,7 +4003,7 @@ mod tests {
             .unwrap()
             .resign();
 
-        let (gossip, mut debut_node, gossip_source) = make_debut(2345, Mode::Standard);
+        let (gossip, mut debut_node, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into());
         let subject = make_subject(&root_node_cryptde);
         let before = time_t_timestamp();
 
@@ -4119,7 +4099,7 @@ mod tests {
             .unwrap()
             .resign();
 
-        let (gossip, debut_node, gossip_source) = make_debut(2345, Mode::Standard);
+        let (gossip, debut_node, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into());
         let subject = make_subject(&root_node_cryptde);
 
         let result = subject.handle(
@@ -4209,7 +4189,7 @@ mod tests {
             .unwrap()
             .resign();
 
-        let (gossip, debut_node, gossip_source) = make_debut(2345, Mode::Standard);
+        let (gossip, debut_node, gossip_source) = make_debut(2345, NeighborhoodModeLight::Standard.into());
         let subject = make_subject(&root_node_cryptde);
 
         let result = subject.handle(
@@ -4399,19 +4379,77 @@ mod tests {
             make_default_neighborhood_metadata(),
         );
 
-        let mut root_node = dest_db.root().clone();
-        root_node.clear_half_neighbors();
-        root_node
-            .add_half_neighbor_key(src_node.public_key().clone())
-            .expect("expected half neighbor");
-        assert_eq!(result, vec![GossipAcceptanceResult::Accepted]);
+        let mut debut_back_node = dest_node.clone();
+        debut_back_node.inner.neighbors.insert(src_node.public_key().clone());
+        debut_back_node.increment_version();
+        debut_back_node.resign();
+        let gnr = GossipNodeRecord::from((
+            debut_back_node.inner.clone(),
+            debut_back_node.node_addr_opt(),
+            GA_CRYPTDE_PAIR.main.as_ref(),
+        ));
+        let debut_back_gossip = Gossip_0v1 {
+            node_records: vec![gnr],
+        };
         assert_eq!(
-            dest_db
-                .node_by_key(dest_node.public_key())
-                .unwrap()
-                .has_half_neighbor(src_node.public_key()),
-            true,
+            result,
+            vec![
+                GossipAcceptanceResult::Reply(
+                    debut_back_gossip,
+                    src_node.public_key().clone(),
+                    src_node.node_addr_opt().unwrap().clone(),
+                )
+            ]
+        )
+    }
+
+    #[test]
+    fn introduction_is_impossible_if_only_candidate_does_not_route_data() {
+        let src_node = make_node_record(1234, true);
+        let src_db = db_from_node(&src_node);
+        let dest_node = make_node_record(2345, true);
+        let mut dest_db: NeighborhoodDatabase = db_from_node(&dest_node);
+        let nonrouting_key = &dest_db
+            .add_node(make_node_record_f(3456, true, true, false))
+            .unwrap();
+        dest_db.add_arbitrary_full_neighbor(dest_node.public_key(), nonrouting_key);
+
+        let debut = GossipBuilder::new(&src_db)
+            .node(src_node.public_key(), true)
+            .build();
+        let debut_agrs = debut.try_into().unwrap();
+        let gossip_source = src_node.node_addr_opt().unwrap().into();
+        let subject = make_subject(GA_CRYPTDE_PAIR.main.as_ref());
+
+        let result = subject.handle(
+            &mut dest_db,
+            debut_agrs,
+            gossip_source,
+            make_default_neighborhood_metadata(),
         );
+
+        let mut debut_back_node = dest_node.clone();
+        debut_back_node.inner.neighbors.insert(src_node.public_key().clone());
+        debut_back_node.increment_version();
+        debut_back_node.resign();
+        let gnr = GossipNodeRecord::from((
+            debut_back_node.inner.clone(),
+            debut_back_node.node_addr_opt(),
+            GA_CRYPTDE_PAIR.main.as_ref(),
+        ));
+        let debut_back_gossip = Gossip_0v1 {
+            node_records: vec![gnr],
+        };
+        assert_eq!(
+            result,
+            vec![
+                GossipAcceptanceResult::Reply(
+                    debut_back_gossip,
+                    src_node.public_key().clone(),
+                    src_node.node_addr_opt().unwrap().clone(),
+                )
+            ]
+        )
     }
 
     fn make_expected_non_introduction_debut_response(
@@ -4475,7 +4513,7 @@ mod tests {
         // This test makes sure GossipAcceptor works correctly
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
-        let (gossip, pass_target, gossip_source) = make_pass(2345, Mode::Standard);
+        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
         let subject = make_subject(GA_CRYPTDE_PAIR.main.as_ref());
 
         let result = subject.handle(
@@ -4505,7 +4543,7 @@ mod tests {
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let subject = PassHandler::new();
-        let (gossip, pass_target, gossip_source) = make_pass(2345, Mode::Standard);
+        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
         let system = System::new("handles_a_new_pass_target");
         let (cpm_recipient, recording_arc) = make_cpm_recipient();
         let mut neighborhood_metadata = make_default_neighborhood_metadata();
@@ -4552,7 +4590,7 @@ mod tests {
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let subject = PassHandler::new();
-        let (gossip, pass_target, gossip_source) = make_pass(2345, Mode::Standard);
+        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
         let pass_target_ip_addr = pass_target.node_addr_opt().unwrap().ip_addr();
         subject.previous_pass_targets.borrow_mut().insert(
             pass_target_ip_addr,
@@ -4599,7 +4637,7 @@ mod tests {
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let subject = PassHandler::new();
-        let (gossip, pass_target, gossip_source) = make_pass(2345, Mode::Standard);
+        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
         let pass_target_ip_addr = pass_target.node_addr_opt().unwrap().ip_addr();
         let system =
             System::new("handles_pass_target_that_is_a_part_of_a_different_connection_progress");
@@ -4636,7 +4674,7 @@ mod tests {
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let subject = PassHandler::new();
-        let (gossip, pass_target, gossip_source) = make_pass(2345, Mode::Standard);
+        let (gossip, pass_target, gossip_source) = make_pass(2345, NeighborhoodModeLight::Standard.into());
         let (cpm_recipient, recording_arc) = make_cpm_recipient();
         let mut neighborhood_metadata = make_default_neighborhood_metadata();
         neighborhood_metadata.cpm_recipient = cpm_recipient;
@@ -5191,6 +5229,59 @@ mod tests {
     }
 
     #[test]
+    fn validate_new_version_is_okay_with_valid_rate_pack() {
+        let test_name = "validate_new_version_is_okay_with_valid_rate_pack";
+        let mut node = make_node_record(1234, true);
+        node.inner.rate_pack = DEFAULT_RATE_PACK.clone();
+        let agr = AccessibleGossipRecord::from(&node);
+
+        let result = GossipAcceptorReal::validate_new_version(
+            &agr,
+            "description".to_string(),
+            &DEFAULT_RATE_PACK_LIMITS,
+            &Logger::new(test_name),
+        );
+
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn validate_new_version_doesnt_like_invalid_rate_pack_if_routes_data() {
+        let test_name = "validate_new_version_doesnt_like_invalid_rate_pack_if_routes_data";
+        let mut node = make_node_record(1234, true);
+        node.inner.routes_data = true;
+        node.inner.rate_pack = ZERO_RATE_PACK.clone();
+        let agr = AccessibleGossipRecord::from(&node);
+
+        let result = GossipAcceptorReal::validate_new_version(
+            &agr,
+            "description".to_string(),
+            &DEFAULT_RATE_PACK_LIMITS,
+            &Logger::new(test_name),
+        );
+
+        assert_eq!(result, Err("description rejected due to rate pack limit violation: ConfiguratorError { param_errors: [ParamError { parameter: \"rate-pack\", reason: \"Value of routing_byte_rate (0) is below the minimum allowed (100)\" }, ParamError { parameter: \"rate-pack\", reason: \"Value of routing_service_rate (0) is below the minimum allowed (100)\" }, ParamError { parameter: \"rate-pack\", reason: \"Value of exit_byte_rate (0) is below the minimum allowed (100)\" }, ParamError { parameter: \"rate-pack\", reason: \"Value of exit_service_rate (0) is below the minimum allowed (100)\" }] }".to_string()));
+    }
+
+    #[test]
+    fn validate_new_version_is_okay_with_invalid_rate_pack_if_doesnt_route_data() {
+        let test_name = "validate_new_version_is_okay_with_invalid_rate_pack_if_doesnt_route_data";
+        let mut node = make_node_record(1234, true);
+        node.inner.routes_data = false;
+        node.inner.rate_pack = ZERO_RATE_PACK.clone();
+        let agr = AccessibleGossipRecord::from(&node);
+
+        let result = GossipAcceptorReal::validate_new_version(
+            &agr,
+            "description".to_string(),
+            &DEFAULT_RATE_PACK_LIMITS,
+            &Logger::new(test_name),
+        );
+
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
     fn find_more_appropriate_neighbor_rejects_twos_and_finds_three() {
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
@@ -5369,6 +5460,57 @@ mod tests {
         );
     }
 
+    #[test]
+    fn should_not_make_another_introduction_says_false_for_0_routing_neighbors() {
+        let root_node = make_node_record(1234, true);
+        let mut db = db_from_node(&root_node);
+        // Two neighbors, but they don't route data, so they don't count.
+        let mut no_routing_1 = make_node_record(2345, true);
+        no_routing_1.inner.routes_data = false;
+        db.add_node(no_routing_1.clone()).unwrap();
+        db.add_arbitrary_full_neighbor(&root_node.public_key(), &no_routing_1.public_key());
+        let mut no_routing_2 = make_node_record(3456, true);
+        no_routing_2.inner.routes_data = false;
+        db.add_node(no_routing_2.clone()).unwrap();
+        db.add_arbitrary_full_neighbor(&root_node.public_key(), &no_routing_2.public_key());
+        let agr = AccessibleGossipRecord::from(db.root());
+
+        let result = DebutHandler::should_not_make_another_introduction(&db, &agr);
+
+        assert_eq!(result, false);
+    }
+
+    #[test]
+    fn should_not_make_another_introduction_says_false_for_1_routing_neighbor() {
+        let root_node = make_node_record(1234, true);
+        let mut db = db_from_node(&root_node);
+        let neighbor = make_node_record(2345, true);
+        db.add_node(neighbor.clone()).unwrap();
+        db.add_arbitrary_full_neighbor(&root_node.public_key(), &neighbor.public_key());
+        let agr = AccessibleGossipRecord::from(db.root());
+
+        let result = DebutHandler::should_not_make_another_introduction(&db, &agr);
+
+        assert_eq!(result, false);
+    }
+
+    #[test]
+    fn should_not_make_another_introduction_says_true_for_2_routing_neighbors() {
+        let root_node = make_node_record(1234, true);
+        let mut db = db_from_node(&root_node);
+        let neighbor_1 = make_node_record(2345, true);
+        db.add_node(neighbor_1.clone()).unwrap();
+        db.add_arbitrary_full_neighbor(&root_node.public_key(), &neighbor_1.public_key());
+        let neighbor_2 = make_node_record(3456, true);
+        db.add_node(neighbor_2.clone()).unwrap();
+        db.add_arbitrary_full_neighbor(&root_node.public_key(), &neighbor_2.public_key());
+        let agr = AccessibleGossipRecord::from(db.root());
+
+        let result = DebutHandler::should_not_make_another_introduction(&db, &agr);
+
+        assert_eq!(result, true);
+    }
+
     fn resign_nodes(db: &mut NeighborhoodDatabase, nodes: Vec<&NodeRecord>) {
         nodes
             .into_iter()
@@ -5405,10 +5547,10 @@ mod tests {
 
     fn make_introduction(introducer_n: u16, introducee_n: u16) -> (Gossip_0v1, SocketAddr) {
         let mut introducer_node: NodeRecord = make_node_record(introducer_n, true);
-        adjust_for_mode(&mut introducer_node, Mode::Standard);
+        adjust_for_mode(&mut introducer_node, NeighborhoodModeLight::Standard.into());
         introducer_node.set_version(10);
         let mut introducee_node: NodeRecord = make_node_record(introducee_n, true);
-        adjust_for_mode(&mut introducee_node, Mode::Standard);
+        adjust_for_mode(&mut introducee_node, NeighborhoodModeLight::Standard.into());
         introducee_node.set_version(10);
         let introducer_key = introducer_node.public_key().clone();
         let introducee_key = introducee_node.public_key().clone();
@@ -5436,18 +5578,11 @@ mod tests {
     }
 
     fn adjust_for_mode(node: &mut NodeRecord, mode: Mode) {
-        match mode {
-            Mode::Standard => {
-                assert!(node.node_addr_opt().is_some());
-                node.inner.accepts_connections = true;
-                node.inner.routes_data = true;
-            }
-            Mode::OriginateOnly => {
-                node.metadata.node_addr_opt = None;
-                node.inner.accepts_connections = false;
-                node.inner.routes_data = true;
-            }
+        if mode.accepts_connections && mode.routes_data {
+            assert!(node.node_addr_opt().is_some());
         }
+        node.inner.accepts_connections = mode.accepts_connections;
+        node.inner.routes_data = mode.routes_data;
     }
 
     fn make_subject(crypt_de: &dyn CryptDE) -> GossipAcceptorReal {

--- a/node/src/neighborhood/gossip_acceptor.rs
+++ b/node/src/neighborhood/gossip_acceptor.rs
@@ -254,6 +254,12 @@ impl GossipHandler for DebutHandler {
     }
 }
 
+enum IntroductionAttempt {
+    Success(Gossip_0v1, PublicKey, NodeAddr),
+    YoungNetworkFailure,
+    CommonNeighborFailure,
+}
+
 impl DebutHandler {
     fn new(rate_pack_limits: &RatePackLimits, logger: Logger) -> DebutHandler {
         DebutHandler {
@@ -304,6 +310,7 @@ impl DebutHandler {
         }
     }
 
+
     fn try_accept_debut(
         &self,
         cryptde: &dyn CryptDE,
@@ -351,14 +358,14 @@ impl DebutHandler {
                     Ok(GossipAcceptanceResult::Accepted)
                 } else {
                     match self.try_to_make_introduction(database, debuting_agr, gossip_source) {
-                        Some((introduction, target_key, target_node_addr)) => {
+                        IntroductionAttempt::Success(introduction, target_key, target_node_addr) => {
                             Ok(GossipAcceptanceResult::Reply(
                                 introduction,
                                 target_key,
                                 target_node_addr,
                             ))
-                        }
-                        None => {
+                        },
+                        IntroductionAttempt::YoungNetworkFailure => {
                             debug!(
                                 self.logger,
                                 "DebutHandler has no one to introduce, but is debuting back to {} at {}",
@@ -384,6 +391,18 @@ impl DebutHandler {
                                     .expect("Debut gossip always has an IP")
                                     .clone(),
                             ))
+                        },
+                        IntroductionAttempt::CommonNeighborFailure => {
+                            debug!(
+                                self.logger,
+                                "DebutHandler shares too many neighbors to be able to introduce a Node; so sending Standard Gossip",
+                            );
+                            trace!(
+                                self.logger,
+                                "DebutHandler database state: {}",
+                                &database.to_dot_graph(),
+                            );
+                            Ok(GossipAcceptanceResult::Accepted)
                         }
                     }
                 }
@@ -422,7 +441,7 @@ impl DebutHandler {
         database: &NeighborhoodDatabase,
         debuting_agr: &AccessibleGossipRecord,
         gossip_source: SocketAddr,
-    ) -> Option<(Gossip_0v1, PublicKey, NodeAddr)> {
+    ) -> IntroductionAttempt {
         if let Some(lcn_key) =
             Self::find_least_connected_full_neighbor_excluding(database, debuting_agr)
         {
@@ -446,16 +465,20 @@ impl DebutHandler {
                 &debuting_agr.inner.public_key,
                 debut_node_addr
             );
-            Some((
+            IntroductionAttempt::Success(
                 GossipBuilder::new(database)
                     .node(database.root().public_key(), true)
                     .node(lcn_key, true)
                     .build(),
                 debuting_agr.inner.public_key.clone(),
                 debut_node_addr,
-            ))
-        } else {
-            None
+            )
+        }
+        else if database.root().full_neighbor_keys(database).is_empty() {
+            IntroductionAttempt::YoungNetworkFailure
+        }
+        else {
+            IntroductionAttempt::CommonNeighborFailure
         }
     }
 
@@ -537,8 +560,9 @@ impl DebutHandler {
         keys
     }
 
-    fn should_not_make_another_introduction(debuting_agr: &AccessibleGossipRecord) -> bool {
-        !debuting_agr.inner.neighbors.is_empty()
+    fn should_not_make_another_introduction(_debuting_agr: &AccessibleGossipRecord) -> bool {
+        false
+        // !debuting_agr.inner.neighbors.is_empty()
     }
 
     fn make_pass_gossip(database: &NeighborhoodDatabase, pass_target: &PublicKey) -> Gossip_0v1 {
@@ -690,7 +714,8 @@ impl GossipHandler for IntroductionHandler {
     // An Introduction must contain two AGRs, one representing the introducer and one representing
     // the introducee. Both records must provide their IP addresses. One of the IP addresses must
     // match the gossip_source. The other record's IP address must not match the gossip_source. The
-    // record whose IP address does not match the gossip source must not already be in the database.
+    // record whose IP address matches the gossip source must not be targeted by a half
+    // neighborship from this Node.
     fn qualifies(
         &self,
         database: &NeighborhoodDatabase,
@@ -709,11 +734,10 @@ impl GossipHandler for IntroductionHandler {
         if let Some(qual) = Self::verify_introducer(introducer, database.root()) {
             return qual;
         };
-        if let Some(qual) = Self::verify_introducee(database, introducer, introducee, gossip_source)
-        {
+        if let Some(qual) = Self::verify_introducee(introducer, introducee, gossip_source) {
             return qual;
         };
-        Qualification::Matched
+        Self::verify_both(database, introducer, introducee)
     }
 
     fn handle(
@@ -915,20 +939,20 @@ impl IntroductionHandler {
     }
 
     fn verify_introducer(
-        agr: &AccessibleGossipRecord,
+        introducer: &AccessibleGossipRecord,
         root_node: &NodeRecord,
     ) -> Option<Qualification> {
-        if &agr.inner.public_key == root_node.public_key() {
+        if &introducer.inner.public_key == root_node.public_key() {
             return Some(Qualification::Malformed(format!(
                 "Introducer {} claims local Node's public key",
-                agr.inner.public_key
+                introducer.inner.public_key
             )));
         }
-        let introducer_node_addr = agr.node_addr_opt.as_ref().expect("NodeAddr disappeared");
+        let introducer_node_addr = introducer.node_addr_opt.as_ref().expect("NodeAddr disappeared");
         if introducer_node_addr.ports().is_empty() {
             return Some(Qualification::Malformed(format!(
                 "Introducer {} from {} has no ports",
-                &agr.inner.public_key,
+                &introducer.inner.public_key,
                 introducer_node_addr.ip_addr()
             )));
         }
@@ -936,7 +960,7 @@ impl IntroductionHandler {
             if introducer_node_addr.ip_addr() == root_node_addr.ip_addr() {
                 return Some(Qualification::Malformed(format!(
                     "Introducer {} claims to be at local Node's IP address",
-                    agr.inner.public_key
+                    introducer.inner.public_key
                 )));
             }
         }
@@ -944,14 +968,10 @@ impl IntroductionHandler {
     }
 
     fn verify_introducee(
-        database: &NeighborhoodDatabase,
         introducer: &AccessibleGossipRecord,
         introducee: &AccessibleGossipRecord,
         gossip_source: SocketAddr,
     ) -> Option<Qualification> {
-        if database.node_by_key(&introducee.inner.public_key).is_some() {
-            return Some(Qualification::Unmatched);
-        }
         let introducee_node_addr = match introducee.node_addr_opt.as_ref() {
             None => return Some(Qualification::Unmatched),
             Some(node_addr) => node_addr,
@@ -983,6 +1003,21 @@ impl IntroductionHandler {
             )));
         }
         None
+    }
+
+    fn verify_both(
+        database: &NeighborhoodDatabase,
+        introducer: &AccessibleGossipRecord,
+        introducee: &AccessibleGossipRecord,
+    ) -> Qualification {
+        let root = database.root();
+        let neighbors = &root.inner.neighbors;
+        if neighbors.contains(&introducer.inner.public_key) && neighbors.contains(&introducee.inner.public_key) {
+            Qualification::Unmatched
+        }
+        else {
+            Qualification::Matched
+        }
     }
 
     fn update_database(
@@ -1854,47 +1889,6 @@ mod tests {
     }
 
     #[test]
-    fn proper_debut_of_node_cant_produce_introduction_because_of_common_neighbor() {
-        let src_root = make_node_record(1234, true);
-        let mut src_db = db_from_node(&src_root);
-        let cryptde = CryptDENull::from(src_db.root().public_key(), TEST_DEFAULT_CHAIN);
-        let dest_root = make_node_record(2345, true);
-        let mut dest_db = db_from_node(&dest_root);
-        let one_common_neighbor = make_node_record(3456, true);
-        let another_common_neighbor = make_node_record(4567, true);
-        src_db.add_node(one_common_neighbor.clone()).unwrap();
-        src_db.add_arbitrary_full_neighbor(src_root.public_key(), one_common_neighbor.public_key());
-        src_db.add_node(another_common_neighbor.clone()).unwrap();
-        src_db.add_arbitrary_full_neighbor(
-            src_root.public_key(),
-            another_common_neighbor.public_key(),
-        );
-        dest_db.add_node(one_common_neighbor.clone()).unwrap();
-        dest_db
-            .add_arbitrary_full_neighbor(dest_root.public_key(), one_common_neighbor.public_key());
-        dest_db.add_node(another_common_neighbor.clone()).unwrap();
-        dest_db.add_arbitrary_full_neighbor(
-            dest_root.public_key(),
-            another_common_neighbor.public_key(),
-        );
-        let gossip = GossipBuilder::new(&src_db)
-            .node(src_db.root().public_key(), true)
-            .build();
-        let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
-        let subject = DebutHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
-
-        let result = subject.handle(
-            &cryptde,
-            &mut dest_db,
-            agrs_vec,
-            src_root.node_addr_opt().unwrap().into(),
-            make_default_neighborhood_metadata(),
-        );
-
-        assert_eq!(result, vec![GossipAcceptanceResult::Accepted]);
-    }
-
-    #[test]
     fn proper_debut_of_node_cant_be_passed_because_of_common_neighbors() {
         let src_root = make_node_record(1234, true);
         let mut src_db = db_from_node(&src_root);
@@ -2005,7 +1999,7 @@ mod tests {
     }
 
     #[test]
-    fn debut_of_already_connected_node_produces_accepted_result_instead_of_introduction_to_prevent_overconnection(
+    fn debut_of_already_connected_node_produces_introduction_because_we_no_longer_care_about_overconnection(
     ) {
         let src_root = make_node_record(1234, true);
         let mut src_db = db_from_node(&src_root);
@@ -2035,8 +2029,53 @@ mod tests {
             make_default_neighborhood_metadata(),
         );
 
-        assert_eq!(result, vec![GossipAcceptanceResult::Accepted]);
+        let expected_acceptance_gossip = GossipBuilder::new(&dest_db)
+            .node(dest_root.public_key(), true)
+            .node(dest_neighbor.public_key(), true)
+            .build();
+        assert_eq!(
+            result,
+            vec![GossipAcceptanceResult::Reply(
+                expected_acceptance_gossip,
+                src_root.public_key().clone(),
+                src_root.node_addr_opt().unwrap(),
+            )]
+        );
     }
+    //
+    // #[test]
+    // fn debut_of_already_connected_node_produces_accepted_result_instead_of_introduction_to_prevent_overconnection(
+    // ) {
+    //     let src_root = make_node_record(1234, true);
+    //     let mut src_db = db_from_node(&src_root);
+    //     let dest_root = make_node_record(2345, true);
+    //     let mut dest_db = db_from_node(&dest_root);
+    //     let dest_cryptde = CryptDENull::from(dest_root.public_key(), TEST_DEFAULT_CHAIN);
+    //     let common_neighbor = make_node_record(3456, true);
+    //     let dest_neighbor = make_node_record(4567, true);
+    //     src_db.add_node(common_neighbor.clone()).unwrap();
+    //     src_db.add_arbitrary_full_neighbor(src_root.public_key(), common_neighbor.public_key());
+    //     dest_db.add_node(common_neighbor.clone()).unwrap();
+    //     dest_db.add_arbitrary_full_neighbor(dest_root.public_key(), common_neighbor.public_key());
+    //     dest_db.add_node(dest_neighbor.clone()).unwrap();
+    //     dest_db.add_arbitrary_full_neighbor(dest_root.public_key(), dest_neighbor.public_key());
+    //     let agrs_vec: Vec<AccessibleGossipRecord> = GossipBuilder::new(&src_db)
+    //         .node(src_root.public_key(), true)
+    //         .build()
+    //         .try_into()
+    //         .unwrap();
+    //     let subject = DebutHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
+    //
+    //     let result = subject.handle(
+    //         &dest_cryptde,
+    //         &mut dest_db,
+    //         agrs_vec,
+    //         dest_root.node_addr_opt().clone().unwrap().into(),
+    //         make_default_neighborhood_metadata(),
+    //     );
+    //
+    //     assert_eq!(result, vec![GossipAcceptanceResult::Accepted]);
+    // }
 
     #[test]
     fn debut_is_rejected_when_validation_fails() {
@@ -2112,6 +2151,49 @@ mod tests {
         };
         assert_eq!(dest_public_key, new_debutant.public_key());
         assert_eq!(dest_node_addr, &new_debutant.node_addr_opt().unwrap());
+    }
+
+    #[test]
+    fn if_we_have_neighbors_but_none_qualify_for_introduction_accept_and_send_standard_gossip() {
+        let test_name = "if_we_have_neighbors_but_none_qualify_for_introduction_accept_and_send_standard_gossip";
+        let dest_root = make_node_record(1234, true);
+        let root_node_cryptde = CryptDENull::from(&dest_root.public_key(), TEST_DEFAULT_CHAIN);
+        let one_common_neighbor = make_node_record(4321, true); // can't introduce this one; debutant already knows it
+        let another_common_neighbor = make_node_record(5432, true); // can't introduce this one; debutant already knows it
+        let mut dest_db = db_from_node(&dest_root);
+        dest_db.add_node(one_common_neighbor.clone()).unwrap();
+        dest_db.add_arbitrary_full_neighbor(
+            dest_root.public_key(),
+            one_common_neighbor.public_key(),
+        );
+        dest_db.add_node(another_common_neighbor.clone()).unwrap();
+        dest_db.add_arbitrary_full_neighbor(
+            dest_root.public_key(),
+            another_common_neighbor.public_key(),
+        );
+
+        let mut debutant = make_node_record(4567, true);
+        debutant.inner.neighbors.insert(one_common_neighbor.public_key().clone());
+        debutant.inner.neighbors.insert(another_common_neighbor.public_key().clone());
+        let logger = Logger::new(test_name);
+        let subject = DebutHandler::new(&RatePackLimits::test_default(), logger);
+        let neighborhood_metadata = make_default_neighborhood_metadata();
+
+        let result = subject
+            .try_accept_debut(
+                &root_node_cryptde,
+                &mut dest_db,
+                &AccessibleGossipRecord::from(&debutant),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(4, 5, 6, 7)), 4567),
+                neighborhood_metadata.user_exit_preferences_opt,
+            )
+            .unwrap();
+
+        match result {
+            GossipAcceptanceResult::Accepted => (),
+            x => panic!("Expected Accepted, got {:?}", x),
+        };
+        assert!(dest_db.root().half_neighbor_keys().contains(debutant.public_key()));
     }
 
     #[test]
@@ -2194,12 +2276,54 @@ mod tests {
     }
 
     #[test]
-    fn introduction_where_introducee_is_in_the_database_is_unmatched() {
+    fn introduction_is_matched_if_receiver_has_half_neighborship_with_introducer_but_not_introducee() {
         let (gossip, gossip_source) = make_introduction(2345, 3456);
-        let not_introducee = make_node_record(3456, true);
+        let introducer_in_target_db = make_node_record(2345, true);
+        let introducee_in_target_db = make_node_record(3456, true);
         let dest_root = make_node_record(7878, true);
         let mut dest_db = db_from_node(&dest_root);
-        dest_db.add_node(not_introducee.clone()).unwrap();
+        dest_db.add_node(introducer_in_target_db.clone()).unwrap();
+        dest_db.add_half_neighbor(introducer_in_target_db.public_key()).unwrap(); //disqualifying
+        dest_db.add_node(introducee_in_target_db.clone()).unwrap();
+        let subject =
+            IntroductionHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
+        let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
+
+        let result = subject.qualifies(&dest_db, agrs_vec.as_slice(), gossip_source);
+
+        assert_eq!(Qualification::Matched, result);
+    }
+
+    #[test]
+    fn introduction_is_matched_if_receiver_has_half_neighborship_with_introducee_but_not_introducer() {
+        let (gossip, gossip_source) = make_introduction(2345, 3456);
+        let introducer_in_target_db = make_node_record(2345, true);
+        let introducee_in_target_db = make_node_record(3456, true);
+        let dest_root = make_node_record(7878, true);
+        let mut dest_db = db_from_node(&dest_root);
+        dest_db.add_node(introducer_in_target_db.clone()).unwrap();
+        dest_db.add_node(introducee_in_target_db.clone()).unwrap();
+        dest_db.add_half_neighbor(introducee_in_target_db.public_key()).unwrap(); //disqualifying
+        let subject =
+            IntroductionHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
+        let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
+
+        let result = subject.qualifies(&dest_db, agrs_vec.as_slice(), gossip_source);
+
+        assert_eq!(Qualification::Matched, result);
+    }
+
+    #[test]
+    fn introduction_is_unmatched_if_receiver_has_half_neighborships_with_both_introducer_and_introducee() {
+        let (gossip, gossip_source) = make_introduction(2345, 3456);
+        let introducer_in_target_db = make_node_record(2345, true);
+        let introducee_in_target_db = make_node_record(3456, true);
+        let dest_root = make_node_record(7878, true);
+        let mut dest_db = db_from_node(&dest_root);
+        dest_db.add_node(introducer_in_target_db.clone()).unwrap();
+        dest_db.add_half_neighbor(introducer_in_target_db.public_key()).unwrap(); //disqualifying
+        dest_db.add_node(introducee_in_target_db.clone()).unwrap();
+        dest_db.add_half_neighbor(introducee_in_target_db.public_key()).unwrap(); //disqualifying
         let subject =
             IntroductionHandler::new(&RatePackLimits::test_default(), Logger::new("test"));
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
@@ -4241,19 +4365,7 @@ mod tests {
         root_node
             .add_half_neighbor_key(src_node.public_key().clone())
             .expect("expected half neighbor");
-        let gnr = GossipNodeRecord::from((
-            root_node.inner.clone(),
-            root_node.node_addr_opt(),
-            GA_CRYPTDE_PAIR.main.as_ref(),
-        ));
-        let debut_gossip = Gossip_0v1 {
-            node_records: vec![gnr],
-        };
-        let expected = vec![make_expected_non_introduction_debut_response(
-            &src_node,
-            debut_gossip,
-        )];
-        assert_eq!(result, expected);
+        assert_eq!(result, vec![GossipAcceptanceResult::Accepted]);
         assert_eq!(
             dest_db
                 .node_by_key(dest_node.public_key())

--- a/node/src/neighborhood/gossip_acceptor.rs
+++ b/node/src/neighborhood/gossip_acceptor.rs
@@ -585,7 +585,8 @@ impl NamedType for PassHandler {
 }
 
 impl GossipHandler for PassHandler {
-    // A Pass must contain a single AGR representing the pass target; it must provide its IP address;
+    // A Pass must contain a single AGR representing the pass target; the pass target must
+    // accept connections; it must provide its IP address;
     // it must specify at least one port; and it must _not_ be sourced by the pass target.
     fn qualifies(
         &self,
@@ -1629,9 +1630,31 @@ impl GossipAcceptor for GossipAcceptorReal {
             Qualification::Unmatched => {
                 panic!("Nothing in gossip_handlers returned Matched or Malformed")
             }
-            Qualification::Malformed(reason) => vec![GossipAcceptanceResult::Ban(Malefactor::new(
-                None, None, None, None, reason,
-            ))],
+            Qualification::Malformed(reason) => {
+                let (
+                    public_key_opt,
+                    ip_address_opt,
+                    earning_wallet_opt,
+                ) = match agrs.iter().find(|agr| {
+                    agr.node_addr_opt.as_ref().map(|na| na.ip_addr()) == Some(gossip_source.ip())
+                }) {
+                    Some(agr) => (
+                        Some(agr.inner.public_key.clone()),
+                        Some(gossip_source.ip()),
+                        Some(agr.inner.earning_wallet.clone()),
+                    ),
+                    None => {
+                        (None, Some(gossip_source.ip()), None)
+                    },
+                };
+                vec![GossipAcceptanceResult::Ban(Malefactor::new(
+                    public_key_opt,
+                    ip_address_opt,
+                    earning_wallet_opt,
+                    None,
+                    reason,
+                ))]
+            },
         }
     }
 }
@@ -2198,7 +2221,7 @@ mod tests {
 
     #[test]
     fn proper_pass_is_identified_and_processed() {
-        let (gossip, pass_target, gossip_source) = make_pass(2345);
+        let (gossip, pass_target, gossip_source) = make_pass(2345, Mode::Standard);
         let subject = PassHandler::new();
         let mut dest_db = make_meaningless_db();
         let cryptde = CryptDENull::from(dest_db.root().public_key(), TEST_DEFAULT_CHAIN);
@@ -2227,9 +2250,25 @@ mod tests {
         );
     }
 
+    fn pass_with_node_that_does_not_accept_connections_is_rejected() {
+        let root_node = make_node_record(1234, true); // irrelevant
+        let mut db = db_from_node(&root_node); // irrelevant
+        let (mut gossip, pass_target, gossip_source) = make_pass(2345, Mode::OriginateOnly);
+        let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
+        let subject = PassHandler::new();
+
+        let result = subject.qualifies(
+            &mut db,
+            agrs_vec.as_slice(),
+            gossip_source,
+        );
+
+        assert_eq!(result, Qualification::Unmatched);
+    }
+
     #[test]
     fn pass_without_node_addr_is_rejected() {
-        let (mut gossip, _, gossip_source) = make_pass(2345);
+        let (mut gossip, _, gossip_source) = make_pass(2345, Mode::Standard);
         gossip.node_records[0].node_addr_opt = None;
         let subject = PassHandler::new();
         let agrs_vec: Vec<AccessibleGossipRecord> = gossip.try_into().unwrap();
@@ -2246,7 +2285,7 @@ mod tests {
 
     #[test]
     fn pass_without_node_addr_ports_is_rejected() {
-        let (mut gossip, _, gossip_source) = make_pass(2345);
+        let (mut gossip, _, gossip_source) = make_pass(2345, Mode::Standard);
         gossip.node_records[0].node_addr_opt =
             Some(NodeAddr::new(&IpAddr::from_str("1.2.3.4").unwrap(), &[]));
         let subject = PassHandler::new();
@@ -3765,7 +3804,7 @@ mod tests {
         let reject_handler = subject.gossip_handlers.last().unwrap();
         let db = make_meaningless_db();
         let (debut, _, debut_gossip_source) = make_debut(1234, Mode::Standard);
-        let (pass, _, pass_gossip_source) = make_pass(2345);
+        let (pass, _, pass_gossip_source) = make_pass(2345, Mode::Standard);
         let (introduction, introduction_gossip_source) = make_introduction(3456, 4567);
         let (standard_gossip, _, standard_gossip_source) = make_debut(9898, Mode::Standard);
         let debut_vec: Vec<AccessibleGossipRecord> = debut.try_into().unwrap();
@@ -4436,7 +4475,7 @@ mod tests {
         // This test makes sure GossipAcceptor works correctly
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
-        let (gossip, pass_target, gossip_source) = make_pass(2345);
+        let (gossip, pass_target, gossip_source) = make_pass(2345, Mode::Standard);
         let subject = make_subject(GA_CRYPTDE_PAIR.main.as_ref());
 
         let result = subject.handle(
@@ -4466,7 +4505,7 @@ mod tests {
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let subject = PassHandler::new();
-        let (gossip, pass_target, gossip_source) = make_pass(2345);
+        let (gossip, pass_target, gossip_source) = make_pass(2345, Mode::Standard);
         let system = System::new("handles_a_new_pass_target");
         let (cpm_recipient, recording_arc) = make_cpm_recipient();
         let mut neighborhood_metadata = make_default_neighborhood_metadata();
@@ -4513,7 +4552,7 @@ mod tests {
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let subject = PassHandler::new();
-        let (gossip, pass_target, gossip_source) = make_pass(2345);
+        let (gossip, pass_target, gossip_source) = make_pass(2345, Mode::Standard);
         let pass_target_ip_addr = pass_target.node_addr_opt().unwrap().ip_addr();
         subject.previous_pass_targets.borrow_mut().insert(
             pass_target_ip_addr,
@@ -4560,7 +4599,7 @@ mod tests {
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let subject = PassHandler::new();
-        let (gossip, pass_target, gossip_source) = make_pass(2345);
+        let (gossip, pass_target, gossip_source) = make_pass(2345, Mode::Standard);
         let pass_target_ip_addr = pass_target.node_addr_opt().unwrap().ip_addr();
         let system =
             System::new("handles_pass_target_that_is_a_part_of_a_different_connection_progress");
@@ -4597,7 +4636,7 @@ mod tests {
         let root_node = make_node_record(1234, true);
         let mut db = db_from_node(&root_node);
         let subject = PassHandler::new();
-        let (gossip, pass_target, gossip_source) = make_pass(2345);
+        let (gossip, pass_target, gossip_source) = make_pass(2345, Mode::Standard);
         let (cpm_recipient, recording_arc) = make_cpm_recipient();
         let mut neighborhood_metadata = make_default_neighborhood_metadata();
         neighborhood_metadata.cpm_recipient = cpm_recipient;
@@ -4786,6 +4825,94 @@ mod tests {
         );
         assert_eq!(dest_db.node_by_key(node_e.public_key()), None);
         assert_eq!(dest_db.node_by_key(node_f.public_key()), None);
+    }
+
+    struct MalformedHandler{}
+    impl NamedType for MalformedHandler { fn type_name(&self) -> &'static str { "MalformedHandler" } }
+    impl GossipHandler for MalformedHandler {
+        fn qualifies(
+            &self,
+            _database: &NeighborhoodDatabase,
+            _agrs: &[AccessibleGossipRecord],
+            _gossip_source: SocketAddr
+        ) -> Qualification {
+            Qualification::Malformed("Malformed for test".to_string())
+        }
+
+        fn handle(
+            &self,
+            _cryptde: &dyn CryptDE,
+            _database: &mut NeighborhoodDatabase,
+            _agrs: Vec<AccessibleGossipRecord>,
+            _gossip_source: SocketAddr,
+            _neighborhood_metadata: NeighborhoodMetadata
+        ) -> Vec<GossipAcceptanceResult> {
+            unimplemented!("Should never be called")
+        }
+    }
+
+    #[test]
+    fn qualification_of_malformed_with_agr_produces_malefactor_ban() {
+        let malformed_handler = Box::new(MalformedHandler{});
+        let dest_root = make_node_record(1234, true);
+        let mut dest_db = db_from_node(&dest_root); // irrelevant
+        let src_root = make_node_record(2345, true);
+        let src_db = db_from_node(&src_root);
+        let gossip = GossipBuilder::new(&src_db)
+            .node(src_root.public_key(), true)
+            .build();
+        let mut subject = make_subject(GA_CRYPTDE_PAIR.main.as_ref());
+        subject.gossip_handlers = vec![malformed_handler];
+
+        let result = subject.handle(
+            &mut dest_db,
+            gossip.try_into().unwrap(),
+            src_root.node_addr_opt().unwrap().into(),
+            make_default_neighborhood_metadata(),
+        );
+
+        assert_eq!(
+            result,
+            vec![GossipAcceptanceResult::Ban(Malefactor::new(
+                Some(src_root.inner.public_key.clone()),
+                Some(src_root.node_addr_opt().unwrap().ip_addr()),
+                Some(src_root.earning_wallet()),
+                None,
+                "Malformed for test".to_string()
+            ))]
+        );
+    }
+
+    #[test]
+    fn qualification_of_malformed_without_agr_produces_malefactor_ban() {
+        let malformed_handler = Box::new(MalformedHandler{});
+        let dest_root = make_node_record(1234, true);
+        let mut dest_db = db_from_node(&dest_root); // irrelevant
+        let src_root = make_node_record(2345, true);
+        let src_db = db_from_node(&src_root);
+        let gossip = GossipBuilder::new(&src_db)
+            .build();
+        let mut subject = make_subject(GA_CRYPTDE_PAIR.main.as_ref());
+        subject.gossip_handlers = vec![malformed_handler];
+        let gossip_source = SocketAddr::from_str("5.5.5.5:5555").unwrap(); // not in Gossip
+
+        let result = subject.handle(
+            &mut dest_db,
+            gossip.try_into().unwrap(),
+            gossip_source, // not in Gossip
+            make_default_neighborhood_metadata(),
+        );
+
+        assert_eq!(
+            result,
+            vec![GossipAcceptanceResult::Ban(Malefactor::new(
+                None,
+                Some(gossip_source.ip()),
+                None,
+                None,
+                "Malformed for test".to_string()
+            ))]
+        );
     }
 
     fn fix_nodes_last_updates(
@@ -5257,8 +5384,8 @@ mod tests {
         (gossip, debut_node, gossip_source)
     }
 
-    fn make_pass(n: u16) -> (Gossip_0v1, NodeRecord, SocketAddr) {
-        let (gossip, debut_node) = make_single_node_gossip(n, Mode::Standard);
+    fn make_pass(n: u16, mode: Mode) -> (Gossip_0v1, NodeRecord, SocketAddr) {
+        let (gossip, debut_node) = make_single_node_gossip(n, mode);
         (
             gossip,
             debut_node,

--- a/node/src/neighborhood/malefactor.rs
+++ b/node/src/neighborhood/malefactor.rs
@@ -66,8 +66,8 @@ impl PartialEq for Malefactor {
             && self.earning_wallet_opt == other.earning_wallet_opt
             && self.consuming_wallet_opt == other.consuming_wallet_opt
             && self.reason == other.reason;
-        let plus_one_second = self.timestamp.saturating_add(FUDGE_FACTOR.clone());
-        let minus_one_second = self.timestamp.saturating_sub(FUDGE_FACTOR.clone());
+        let plus_one_second = self.timestamp.saturating_add(*FUDGE_FACTOR);
+        let minus_one_second = self.timestamp.saturating_sub(*FUDGE_FACTOR);
         equal && (other.timestamp >= minus_one_second && other.timestamp <= plus_one_second)
     }
 }
@@ -133,6 +133,7 @@ impl Malefactor {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::str::FromStr;

--- a/node/src/neighborhood/malefactor.rs
+++ b/node/src/neighborhood/malefactor.rs
@@ -1,0 +1,448 @@
+use crate::neighborhood::gossip::AccessibleGossipRecord;
+use crate::neighborhood::node_record::NodeRecord;
+use crate::sub_lib::cryptde::PublicKey;
+use crate::sub_lib::wallet::Wallet;
+use lazy_static::lazy_static;
+use std::fmt::{Display, Formatter};
+use std::net::IpAddr;
+use time::{OffsetDateTime, PrimitiveDateTime};
+
+lazy_static! {
+    pub static ref FUDGE_FACTOR: time::Duration = time::Duration::seconds(1);
+}
+
+#[derive(Clone, Debug, Eq)]
+pub struct Malefactor {
+    pub public_key_opt: Option<PublicKey>,
+    pub ip_address_opt: Option<IpAddr>,
+    pub earning_wallet_opt: Option<Wallet>,
+    pub consuming_wallet_opt: Option<Wallet>,
+    pub timestamp: PrimitiveDateTime,
+    pub reason: String,
+}
+
+impl Display for Malefactor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Malefactor{}{}{} detected at {}: {}",
+            match &self.public_key_opt {
+                Some(pk) => format!(" {}", pk),
+                None => "".to_string(),
+            },
+            match &self.ip_address_opt {
+                Some(ip) => format!(" at {}", ip),
+                None => "".to_string(),
+            },
+            match &self.earning_wallet_opt {
+                Some(wallet) => format!(" with earning wallet {}", wallet),
+                None => "".to_string(),
+            } + &match (
+                &self.earning_wallet_opt.is_some(),
+                &self.consuming_wallet_opt
+            ) {
+                (true, Some(wallet)) => format!(", consuming wallet {}", wallet),
+                (false, Some(wallet)) => format!(" with consuming wallet {}", wallet),
+                (_, None) => "".to_string(),
+            },
+            self.timestamp,
+            self.reason
+        )
+    }
+}
+
+impl PartialEq for Malefactor {
+    // Logic behind this custom implementation:
+    // The only place we will ever compare Malefactors for equality is in tests. In tests,
+    // the Malefactor that is generated in the production code and the Malefactor that is used
+    // for assertion will frequently be created a few microseconds apart, and therefore their
+    // timestamps will not be identical and the equality assertion will fail, even when the two
+    // are logically the same. Therefore, this custom implementation will consider two Malefactors
+    // equal if their timestamps are within FUDGE_FACTOR of each other and all their other fields are
+    // equal.
+    fn eq(&self, other: &Self) -> bool {
+        let equal = self.public_key_opt == other.public_key_opt
+            && self.ip_address_opt == other.ip_address_opt
+            && self.earning_wallet_opt == other.earning_wallet_opt
+            && self.consuming_wallet_opt == other.consuming_wallet_opt
+            && self.reason == other.reason;
+        let plus_one_second = self.timestamp.saturating_add(FUDGE_FACTOR.clone());
+        let minus_one_second = self.timestamp.saturating_sub(FUDGE_FACTOR.clone());
+        equal && (other.timestamp >= minus_one_second && other.timestamp <= plus_one_second)
+    }
+}
+
+impl From<(&NodeRecord, String)> for Malefactor {
+    fn from(pair: (&NodeRecord, String)) -> Self {
+        let (node_record, reason) = pair;
+        Self::new(
+            Some(node_record.public_key().clone()),
+            node_record
+                .metadata
+                .node_addr_opt
+                .as_ref()
+                .map(|na| na.ip_addr()),
+            Some(node_record.inner.earning_wallet.clone()),
+            None,
+            reason,
+        )
+    }
+}
+
+impl From<(&AccessibleGossipRecord, String)> for Malefactor {
+    fn from(pair: (&AccessibleGossipRecord, String)) -> Self {
+        let (agr, reason) = pair;
+        Self::new(
+            Some(agr.inner.public_key.clone()),
+            agr.node_addr_opt.as_ref().map(|na| na.ip_addr()),
+            Some(agr.inner.earning_wallet.clone()),
+            None,
+            reason,
+        )
+    }
+}
+
+impl Malefactor {
+    pub fn new(
+        public_key_opt: Option<PublicKey>,
+        ip_address_opt: Option<IpAddr>,
+        earning_wallet_opt: Option<Wallet>,
+        consuming_wallet_opt: Option<Wallet>,
+        reason: String,
+    ) -> Self {
+        if public_key_opt.is_none()
+            && ip_address_opt.is_none()
+            && earning_wallet_opt.is_none()
+            && consuming_wallet_opt.is_none()
+        {
+            panic!("Malefactor must have at least one identifying attribute");
+        }
+        Self {
+            public_key_opt,
+            ip_address_opt,
+            earning_wallet_opt,
+            consuming_wallet_opt,
+            timestamp: Self::timestamp(),
+            reason,
+        }
+    }
+
+    fn timestamp() -> PrimitiveDateTime {
+        let odt = OffsetDateTime::now_local().unwrap_or_else(|_| OffsetDateTime::now_utc());
+        PrimitiveDateTime::new(odt.date(), odt.time())
+    }
+}
+
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[should_panic(expected = "Malefactor must have at least one identifying attribute")]
+    #[test]
+    fn doesnt_tolerate_all_nones() {
+        let _ = Malefactor::new(None, None, None, None, "Bad Smell".to_string());
+    }
+
+    #[test]
+    fn timestamps_properly() {
+        let before = Malefactor::timestamp();
+
+        let malefactor = Malefactor::new(
+            Some(PublicKey::from(&b"Booga"[..])),
+            None,
+            None,
+            None,
+            "Bad Smell".to_string(),
+        );
+
+        let after = Malefactor::timestamp();
+        assert!(malefactor.timestamp >= before);
+        assert!(malefactor.timestamp <= after);
+    }
+
+    #[test]
+    fn displays_public_key() {
+        let public_key = PublicKey::from(&b"Booga"[..]);
+        let malefactor = Malefactor {
+            public_key_opt: Some(public_key),
+            ip_address_opt: None,
+            earning_wallet_opt: None,
+            consuming_wallet_opt: None,
+            timestamp: PrimitiveDateTime::new(
+                time::Date::from_calendar_date(2024, time::Month::June, 1).unwrap(),
+                time::Time::from_hms(12, 34, 56).unwrap(),
+            ),
+            reason: "Bad Smell".to_string(),
+        };
+
+        let string = format!("{}", malefactor);
+
+        assert_eq!(
+            string,
+            "Malefactor Qm9vZ2E detected at 2024-06-01 12:34:56.0: Bad Smell".to_string()
+        );
+    }
+
+    #[test]
+    fn displays_ip_address() {
+        let ip_address = IpAddr::from_str("12.34.56.78").unwrap();
+        let malefactor = Malefactor {
+            public_key_opt: None,
+            ip_address_opt: Some(ip_address),
+            earning_wallet_opt: None,
+            consuming_wallet_opt: None,
+            timestamp: PrimitiveDateTime::new(
+                time::Date::from_calendar_date(2024, time::Month::June, 1).unwrap(),
+                time::Time::from_hms(12, 34, 56).unwrap(),
+            ),
+            reason: "Bad Smell".to_string(),
+        };
+
+        let string = format!("{}", malefactor);
+
+        assert_eq!(
+            string,
+            "Malefactor at 12.34.56.78 detected at 2024-06-01 12:34:56.0: Bad Smell".to_string()
+        );
+    }
+
+    #[test]
+    fn displays_earning_wallet() {
+        let earning_wallet =
+            Wallet::from_str("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee").unwrap();
+        let malefactor = Malefactor {
+            public_key_opt: None,
+            ip_address_opt: None,
+            earning_wallet_opt: Some(earning_wallet),
+            consuming_wallet_opt: None,
+            timestamp: PrimitiveDateTime::new(
+                time::Date::from_calendar_date(2024, time::Month::June, 1).unwrap(),
+                time::Time::from_hms(12, 34, 56).unwrap(),
+            ),
+            reason: "Bad Smell".to_string(),
+        };
+
+        let string = format!("{}", malefactor);
+
+        assert_eq!(
+            string,
+            "Malefactor with earning wallet 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee detected at 2024-06-01 12:34:56.0: Bad Smell".to_string()
+        );
+    }
+
+    #[test]
+    fn displays_consuming_wallet() {
+        let consuming_wallet =
+            Wallet::from_str("0xcccccccccccccccccccccccccccccccccccccccc").unwrap();
+        let malefactor = Malefactor {
+            public_key_opt: None,
+            ip_address_opt: None,
+            earning_wallet_opt: None,
+            consuming_wallet_opt: Some(consuming_wallet),
+            timestamp: PrimitiveDateTime::new(
+                time::Date::from_calendar_date(2024, time::Month::June, 1).unwrap(),
+                time::Time::from_hms(12, 34, 56).unwrap(),
+            ),
+            reason: "Bad Smell".to_string(),
+        };
+
+        let string = format!("{}", malefactor);
+
+        assert_eq!(
+            string,
+            "Malefactor with consuming wallet 0xcccccccccccccccccccccccccccccccccccccccc detected at 2024-06-01 12:34:56.0: Bad Smell".to_string()
+        );
+    }
+
+    #[test]
+    fn displays_all_fields() {
+        let public_key = PublicKey::from(&b"Booga"[..]);
+        let ip_address = IpAddr::from_str("12.34.56.78").unwrap();
+        let earning_wallet =
+            Wallet::from_str("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee").unwrap();
+        let consuming_wallet =
+            Wallet::from_str("0xcccccccccccccccccccccccccccccccccccccccc").unwrap();
+        let malefactor = Malefactor {
+            public_key_opt: Some(public_key),
+            ip_address_opt: Some(ip_address),
+            earning_wallet_opt: Some(earning_wallet),
+            consuming_wallet_opt: Some(consuming_wallet),
+            timestamp: PrimitiveDateTime::new(
+                time::Date::from_calendar_date(2024, time::Month::June, 1).unwrap(),
+                time::Time::from_hms(12, 34, 56).unwrap(),
+            ),
+            reason: "Bad Smell".to_string(),
+        };
+
+        let string = format!("{}", malefactor);
+
+        assert_eq!(
+            string,
+            "Malefactor Qm9vZ2E at 12.34.56.78 with earning wallet 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, consuming wallet 0xcccccccccccccccccccccccccccccccccccccccc detected at 2024-06-01 12:34:56.0: Bad Smell".to_string()
+        );
+    }
+
+    #[test]
+    fn eq_works_for_equal_timestamps() {
+        let public_key = PublicKey::from(&b"Booga"[..]);
+        let ip_address = IpAddr::from_str("12.34.56.78").unwrap();
+        let earning_wallet =
+            Wallet::from_str("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee").unwrap();
+        let consuming_wallet =
+            Wallet::from_str("0xcccccccccccccccccccccccccccccccccccccccc").unwrap();
+        let timestamp = PrimitiveDateTime::new(
+            time::Date::from_calendar_date(2024, time::Month::June, 1).unwrap(),
+            time::Time::from_hms(12, 34, 56).unwrap(),
+        );
+        let reason = "Bad Smell".to_string();
+        let a = Malefactor {
+            public_key_opt: Some(public_key.clone()),
+            ip_address_opt: Some(ip_address.clone()),
+            earning_wallet_opt: Some(earning_wallet.clone()),
+            consuming_wallet_opt: Some(consuming_wallet.clone()),
+            timestamp,
+            reason: reason.clone(),
+        };
+        let b = Malefactor {
+            public_key_opt: Some(public_key.clone()),
+            ip_address_opt: Some(ip_address.clone()),
+            earning_wallet_opt: Some(earning_wallet.clone()),
+            consuming_wallet_opt: Some(consuming_wallet.clone()),
+            timestamp,
+            reason: reason.clone(),
+        };
+        let c = Malefactor {
+            public_key_opt: None,
+            ip_address_opt: Some(ip_address.clone()),
+            earning_wallet_opt: Some(earning_wallet.clone()),
+            consuming_wallet_opt: Some(consuming_wallet.clone()),
+            timestamp,
+            reason: reason.clone(),
+        };
+        let d = Malefactor {
+            public_key_opt: Some(public_key.clone()),
+            ip_address_opt: None,
+            earning_wallet_opt: Some(earning_wallet.clone()),
+            consuming_wallet_opt: Some(consuming_wallet.clone()),
+            timestamp,
+            reason: reason.clone(),
+        };
+        let e = Malefactor {
+            public_key_opt: Some(public_key.clone()),
+            ip_address_opt: Some(ip_address.clone()),
+            earning_wallet_opt: None,
+            consuming_wallet_opt: Some(consuming_wallet.clone()),
+            timestamp,
+            reason: reason.clone(),
+        };
+        let f = Malefactor {
+            public_key_opt: Some(public_key.clone()),
+            ip_address_opt: Some(ip_address.clone()),
+            earning_wallet_opt: Some(earning_wallet.clone()),
+            consuming_wallet_opt: None,
+            timestamp,
+            reason: reason.clone(),
+        };
+        let g = Malefactor {
+            public_key_opt: Some(public_key.clone()),
+            ip_address_opt: Some(ip_address.clone()),
+            earning_wallet_opt: Some(earning_wallet.clone()),
+            consuming_wallet_opt: Some(consuming_wallet.clone()),
+            timestamp,
+            reason: "".to_string(),
+        };
+
+        assert_eq!(a, a);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(a, d);
+        assert_ne!(a, e);
+        assert_ne!(a, f);
+        assert_ne!(a, g);
+    }
+
+    #[test]
+    fn eq_says_true_for_timestamps_exactly_one_second_apart() {
+        let public_key = PublicKey::from(&b"Booga"[..]);
+        let ip_address = IpAddr::from_str("12.34.56.78").unwrap();
+        let earning_wallet =
+            Wallet::from_str("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee").unwrap();
+        let consuming_wallet =
+            Wallet::from_str("0xcccccccccccccccccccccccccccccccccccccccc").unwrap();
+        let timestamp_early = PrimitiveDateTime::new(
+            time::Date::from_calendar_date(2024, time::Month::June, 1).unwrap(),
+            time::Time::from_hms(12, 34, 56).unwrap(),
+        );
+        let timestamp_late = timestamp_early.saturating_add(FUDGE_FACTOR.clone());
+        let reason = "Bad Smell".to_string();
+        let a = Malefactor {
+            public_key_opt: Some(public_key.clone()),
+            ip_address_opt: Some(ip_address.clone()),
+            earning_wallet_opt: Some(earning_wallet.clone()),
+            consuming_wallet_opt: Some(consuming_wallet.clone()),
+            timestamp: timestamp_early,
+            reason: reason.clone(),
+        };
+        let b = Malefactor {
+            public_key_opt: Some(public_key.clone()),
+            ip_address_opt: Some(ip_address.clone()),
+            earning_wallet_opt: Some(earning_wallet.clone()),
+            consuming_wallet_opt: Some(consuming_wallet.clone()),
+            timestamp: timestamp_late,
+            reason: reason.clone(),
+        };
+
+        assert_eq!(a, b);
+        assert_eq!(b, a);
+    }
+
+    #[test]
+    fn eq_says_false_for_timestamps_more_than_one_second_apart() {
+        let public_key = PublicKey::from(&b"Booga"[..]);
+        let ip_address = IpAddr::from_str("12.34.56.78").unwrap();
+        let earning_wallet =
+            Wallet::from_str("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee").unwrap();
+        let consuming_wallet =
+            Wallet::from_str("0xcccccccccccccccccccccccccccccccccccccccc").unwrap();
+        let timestamp_early = PrimitiveDateTime::new(
+            time::Date::from_calendar_date(2024, time::Month::June, 1).unwrap(),
+            time::Time::from_hms(12, 34, 56).unwrap(),
+        );
+        let timestamp_middle = timestamp_early
+            .saturating_add(FUDGE_FACTOR.saturating_add(time::Duration::milliseconds(1)));
+        let timestamp_late = timestamp_middle
+            .saturating_add(FUDGE_FACTOR.saturating_add(time::Duration::milliseconds(1)));
+        let reason = "Bad Smell".to_string();
+        let a = Malefactor {
+            public_key_opt: Some(public_key.clone()),
+            ip_address_opt: Some(ip_address.clone()),
+            earning_wallet_opt: Some(earning_wallet.clone()),
+            consuming_wallet_opt: Some(consuming_wallet.clone()),
+            timestamp: timestamp_early,
+            reason: reason.clone(),
+        };
+        let b = Malefactor {
+            public_key_opt: Some(public_key.clone()),
+            ip_address_opt: Some(ip_address.clone()),
+            earning_wallet_opt: Some(earning_wallet.clone()),
+            consuming_wallet_opt: Some(consuming_wallet.clone()),
+            timestamp: timestamp_middle,
+            reason: reason.clone(),
+        };
+        let c = Malefactor {
+            public_key_opt: Some(public_key.clone()),
+            ip_address_opt: Some(ip_address.clone()),
+            earning_wallet_opt: Some(earning_wallet.clone()),
+            consuming_wallet_opt: Some(consuming_wallet.clone()),
+            timestamp: timestamp_late,
+            reason: reason.clone(),
+        };
+
+        assert_ne!(a, b);
+        assert_ne!(b, a);
+        assert_ne!(b, c);
+        assert_ne!(c, b);
+        assert_ne!(a, c);
+        assert_ne!(c, a);
+    }
+}

--- a/node/src/neighborhood/mod.rs
+++ b/node/src/neighborhood/mod.rs
@@ -11,8 +11,6 @@ pub mod node_record;
 pub mod overall_connection_status;
 
 use crate::bootstrapper::{BootstrapperConfig, CryptDEPair};
-use crate::database::db_initializer::DbInitializationConfig;
-use crate::database::db_initializer::{DbInitializer, DbInitializerReal};
 use crate::db_config::persistent_configuration::{
     PersistentConfigError, PersistentConfiguration, PersistentConfigurationFactory,
     PersistentConfigurationFactoryReal, PersistentConfigurationInvalid,
@@ -79,7 +77,7 @@ use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::net::{IpAddr, SocketAddr};
-use std::path::PathBuf;
+// use std::path::PathBuf;
 use std::string::ToString;
 
 pub const CRASH_KEY: &str = "NEIGHBORHOOD";
@@ -109,7 +107,7 @@ pub struct Neighborhood {
     overall_connection_status: OverallConnectionStatus,
     chain: Chain,
     crashable: bool,
-    data_directory: PathBuf,
+    // data_directory: PathBuf,
     persistent_config_factory: Box<dyn PersistentConfigurationFactory>,
     persistent_config: Box<dyn PersistentConfiguration>,
     db_password_opt: Option<String>,
@@ -435,7 +433,7 @@ impl Neighborhood {
             overall_connection_status,
             chain: config.blockchain_bridge_config.chain,
             crashable: config.crash_point == CrashPoint::Message,
-            data_directory: config.data_directory.clone(),
+            // data_directory: config.data_directory.clone(),
             persistent_config_factory: Box::new(PersistentConfigurationFactoryReal::new(
                 config.data_directory.clone(),
             )),
@@ -2264,6 +2262,7 @@ mod tests {
     use crate::test_utils::database_utils::PersistentConfigurationFactoryTest;
     use crate::test_utils::unshared_test_utils::notify_handlers::NotifyLaterHandleMock;
     use masq_lib::test_utils::logging::{init_test_logging, TestLogHandler};
+    use crate::database::db_initializer::{DbInitializationConfig, DbInitializer, DbInitializerReal};
 
     lazy_static! {
         static ref N_CRYPTDE_PAIR: CryptDEPair = CryptDEPair::null();
@@ -2602,7 +2601,7 @@ mod tests {
                 .min_hops_result(Ok(MIN_HOPS_FOR_TEST))
                 .rate_pack_limits_result(Ok(RatePackLimits::test_default())),
         ));
-        subject.data_directory = data_dir;
+        // subject.data_directory = data_dir;
         let addr = subject.start();
         let sub = addr.clone().recipient::<StartMessage>();
         let (hopper, _, hopper_recording_arc) = make_recorder();
@@ -6285,7 +6284,7 @@ mod tests {
         let hopper_recording = hopper_recording_arc.lock().unwrap();
         assert_eq!(0, hopper_recording.len());
         let tlh = TestLogHandler::new();
-        tlh.exists_log_containing("WARN: Neighborhood: Malefactor detected at 5.5.5.5:5555, but malefactor bans not yet implemented; ignoring: Bad guy");
+        tlh.exists_log_containing("WARN: Neighborhood: Malefactor detected at 5.5.5.5:5555, but malefactor bans not yet implemented; ignoring: Malefactor QmFkR3V5UHVibGljS2V5 at 1.3.2.4 with earning wallet 0x004261644775794561726e696e6757616c6c6574, consuming wallet 0x426164477579436f6e73756d696e6757616c6c65 detected at 2024-04-01 3:04:05.0: Bad guy");
     }
 
     #[test]
@@ -6463,7 +6462,7 @@ mod tests {
                 .min_hops_result(Ok(MIN_HOPS_FOR_TEST))
                 .rate_pack_limits_result(Ok(RatePackLimits::test_default())),
         ));
-        subject.data_directory = data_dir;
+        // subject.data_directory = data_dir;
         subject.logger = Logger::new("node_gossips_to_neighbors_on_startup");
         let this_node = subject.neighborhood_database.root().clone();
         let system = System::new("node_gossips_to_neighbors_on_startup");
@@ -7608,9 +7607,9 @@ mod tests {
                 N_CRYPTDE_PAIR.clone(),
                 &bc_from_earning_wallet(make_wallet("earning_wallet")),
             );
-            subject.data_directory = data_dir.to_path_buf();
+            // subject.data_directory = data_dir.to_path_buf();
             subject.persistent_config_factory = Box::new(PersistentConfigurationFactoryReal::new(
-                subject.data_directory.clone(),
+                data_dir.to_path_buf(),
             ));
             subject.persistent_config_factory.make();
         };

--- a/node/src/neighborhood/mod.rs
+++ b/node/src/neighborhood/mod.rs
@@ -768,7 +768,7 @@ impl Neighborhood {
             db_patch_size: self.db_patch_size,
             user_exit_preferences_opt: Some(self.user_exit_preferences.clone()),
         };
-        let mut acceptance_results = self.gossip_acceptor.handle(
+        let acceptance_results = self.gossip_acceptor.handle(
             &mut self.neighborhood_database,
             agrs,
             gossip_source,

--- a/node/src/neighborhood/mod.rs
+++ b/node/src/neighborhood/mod.rs
@@ -2252,6 +2252,9 @@ mod tests {
     use super::*;
     use crate::accountant::test_utils::bc_from_earning_wallet;
     use crate::bootstrapper::CryptDEPair;
+    use crate::database::db_initializer::{
+        DbInitializationConfig, DbInitializer, DbInitializerReal,
+    };
     use crate::neighborhood::malefactor::Malefactor;
     use crate::neighborhood::overall_connection_status::ConnectionStageErrors::{
         NoGossipResponseReceived, PassLoopFound, TcpConnectionFailed,
@@ -2262,7 +2265,6 @@ mod tests {
     use crate::test_utils::database_utils::PersistentConfigurationFactoryTest;
     use crate::test_utils::unshared_test_utils::notify_handlers::NotifyLaterHandleMock;
     use masq_lib::test_utils::logging::{init_test_logging, TestLogHandler};
-    use crate::database::db_initializer::{DbInitializationConfig, DbInitializer, DbInitializerReal};
 
     lazy_static! {
         static ref N_CRYPTDE_PAIR: CryptDEPair = CryptDEPair::null();

--- a/node/src/neighborhood/mod.rs
+++ b/node/src/neighborhood/mod.rs
@@ -15,7 +15,9 @@ use crate::db_config::persistent_configuration::{
     PersistentConfigError, PersistentConfiguration, PersistentConfigurationFactory,
     PersistentConfigurationFactoryReal, PersistentConfigurationInvalid,
 };
-use crate::neighborhood::gossip::{agrs_to_string, AccessibleGossipRecord, DotGossipEndpoint, Gossip_0v1};
+use crate::neighborhood::gossip::{
+    agrs_to_string, AccessibleGossipRecord, DotGossipEndpoint, Gossip_0v1,
+};
 use crate::neighborhood::gossip_acceptor::{GossipAcceptanceResult, GossipAcceptorInvalid};
 use crate::neighborhood::node_location::get_node_location;
 use crate::neighborhood::overall_connection_status::{

--- a/node/src/neighborhood/mod.rs
+++ b/node/src/neighborhood/mod.rs
@@ -818,6 +818,7 @@ impl Neighborhood {
         neighbor_keys_after: HashSet<PublicKey>,
     ) {
         self.curate_past_neighbors(neighbor_keys_before, neighbor_keys_after);
+        // TODO: This shouldn't be done if there were no changes to the database.
         self.check_connectedness();
     }
 

--- a/node/src/neighborhood/mod.rs
+++ b/node/src/neighborhood/mod.rs
@@ -15,7 +15,7 @@ use crate::db_config::persistent_configuration::{
     PersistentConfigError, PersistentConfiguration, PersistentConfigurationFactory,
     PersistentConfigurationFactoryReal, PersistentConfigurationInvalid,
 };
-use crate::neighborhood::gossip::{AccessibleGossipRecord, DotGossipEndpoint, Gossip_0v1};
+use crate::neighborhood::gossip::{agrs_to_string, AccessibleGossipRecord, DotGossipEndpoint, Gossip_0v1};
 use crate::neighborhood::gossip_acceptor::{GossipAcceptanceResult, GossipAcceptorInvalid};
 use crate::neighborhood::node_location::get_node_location;
 use crate::neighborhood::overall_connection_status::{
@@ -688,6 +688,8 @@ impl Neighborhood {
             self.announce_gossip_handling_completion(record_count);
             return;
         }
+
+        trace!(self.logger, "Contents: {}", agrs_to_string(agrs.as_slice()));
 
         self.handle_gossip_agrs(agrs, gossip_source, cpm_recipient);
         self.announce_gossip_handling_completion(record_count);

--- a/node/src/neighborhood/neighborhood_database.rs
+++ b/node/src/neighborhood/neighborhood_database.rs
@@ -313,7 +313,7 @@ impl NeighborhoodDatabase {
                         country_code,
                     }),
                     public_key: public_key.clone(),
-                    node_addr: nr.node_addr_opt(),
+                    node_addr_opt: nr.node_addr_opt(),
                     known_source: public_key == self.root().public_key(),
                     known_target: false,
                     is_present: true,
@@ -323,7 +323,7 @@ impl NeighborhoodDatabase {
             node_renderables.push(NodeRenderable {
                 inner: None,
                 public_key: k.clone(),
-                node_addr: None,
+                node_addr_opt: None,
                 known_source: false,
                 known_target: false,
                 is_present: false,

--- a/node/src/neighborhood/node_record.rs
+++ b/node/src/neighborhood/node_record.rs
@@ -10,13 +10,13 @@ use crate::sub_lib::neighborhood::{NodeDescriptor, RatePack};
 use crate::sub_lib::node_addr::NodeAddr;
 use crate::sub_lib::utils::time_t_timestamp;
 use crate::sub_lib::wallet::Wallet;
+use itertools::Itertools;
 use masq_lib::blockchains::chains::Chain;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::btree_set::BTreeSet;
 use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::fmt::{Display, Formatter};
-use itertools::Itertools;
 
 //TODO #584 create special serializer for NodeRecordInner_0v1
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -53,8 +53,8 @@ impl TryFrom<&GossipNodeRecord> for NodeRecordInner_0v1 {
 
 impl Display for NodeRecordInner_0v1 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let accepts_connections = if self.accepts_connections {"A"} else {"a"};
-        let routes_data = if self.routes_data {"R"} else {"r"};
+        let accepts_connections = if self.accepts_connections { "A" } else { "a" };
+        let routes_data = if self.routes_data { "R" } else { "r" };
         let version = format!("v{}", self.version);
         let country_code = match &self.country_code_opt {
             Some(cc) => cc.clone(),
@@ -64,7 +64,9 @@ impl Display for NodeRecordInner_0v1 {
         let mut public_key = self.public_key.to_string();
         public_key.truncate(8);
         let rate_pack = self.rate_pack.rate_pack_parameter();
-        let neighbors = self.neighbors.iter()
+        let neighbors = self
+            .neighbors
+            .iter()
             .map(|it| {
                 let mut s = it.to_string();
                 s.truncate(8);
@@ -75,7 +77,14 @@ impl Display for NodeRecordInner_0v1 {
         write!(
             f,
             "{}{} {} {} {} {} {} [{}]",
-            accepts_connections, routes_data, version, country_code, public_key, wallet, rate_pack, neighbors
+            accepts_connections,
+            routes_data,
+            version,
+            country_code,
+            public_key,
+            wallet,
+            rate_pack,
+            neighbors
         )
     }
 }
@@ -465,7 +474,8 @@ mod tests {
         subject.inner.routes_data = false;
         subject.inner.version = 19;
         subject.inner.country_code_opt = None;
-        subject.inner.earning_wallet = Wallet::from_str("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee").unwrap();
+        subject.inner.earning_wallet =
+            Wallet::from_str("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee").unwrap();
         subject.inner.rate_pack = RatePack::new(100, 200, 300, 400);
         let neighbor1 = PublicKey::new(&b"fiddle"[..]);
         let neighbor2 = PublicKey::new(&b"diffle"[..]);
@@ -488,17 +498,17 @@ mod tests {
         subject.inner.routes_data = true;
         subject.inner.version = 91;
         subject.inner.country_code_opt = Some("US".to_string());
-        subject.inner.earning_wallet = Wallet::from_str("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee00").unwrap();
+        subject.inner.earning_wallet =
+            Wallet::from_str("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee00").unwrap();
         subject.inner.rate_pack = RatePack::new(400, 300, 200, 100);
-        subject.inner.neighbors = vec![]
-            .into_iter()
-            .collect::<BTreeSet<PublicKey>>();
+        subject.inner.neighbors = vec![].into_iter().collect::<BTreeSet<PublicKey>>();
 
         let result = subject.inner.to_string();
 
         assert_eq!(
             result,
-            "AR v91 US AgMEBQ 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee00 400|300|200|100 []".to_string()
+            "AR v91 US AgMEBQ 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee00 400|300|200|100 []"
+                .to_string()
         )
     }
 

--- a/node/src/neighborhood/node_record.rs
+++ b/node/src/neighborhood/node_record.rs
@@ -15,6 +15,8 @@ use serde_derive::{Deserialize, Serialize};
 use std::collections::btree_set::BTreeSet;
 use std::collections::HashSet;
 use std::convert::TryFrom;
+use std::fmt::{Display, Formatter};
+use itertools::Itertools;
 
 //TODO #584 create special serializer for NodeRecordInner_0v1
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -46,6 +48,35 @@ impl TryFrom<&GossipNodeRecord> for NodeRecordInner_0v1 {
 
     fn try_from(gnr_addr_ref: &GossipNodeRecord) -> Result<Self, Self::Error> {
         NodeRecordInner_0v1::try_from(gnr_addr_ref.clone())
+    }
+}
+
+impl Display for NodeRecordInner_0v1 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let accepts_connections = if self.accepts_connections {"A"} else {"a"};
+        let routes_data = if self.routes_data {"R"} else {"r"};
+        let version = format!("v{}", self.version);
+        let country_code = match &self.country_code_opt {
+            Some(cc) => cc.clone(),
+            None => "ZZ".to_string(),
+        };
+        let wallet = self.earning_wallet.to_string();
+        let mut public_key = self.public_key.to_string();
+        public_key.truncate(8);
+        let rate_pack = self.rate_pack.rate_pack_parameter();
+        let neighbors = self.neighbors.iter()
+            .map(|it| {
+                let mut s = it.to_string();
+                s.truncate(8);
+                s
+            })
+            .collect_vec()
+            .join(", ");
+        write!(
+            f,
+            "{}{} {} {} {} {} {} [{}]",
+            accepts_connections, routes_data, version, country_code, public_key, wallet, rate_pack, neighbors
+        )
     }
 }
 
@@ -425,6 +456,50 @@ mod tests {
         assert_eq!(actual_node_record.inner.country_code_opt, Some(expected_cc));
         expected_node_record.metadata.last_update = actual_node_record.metadata.last_update;
         assert_eq!(actual_node_record, expected_node_record);
+    }
+
+    #[test]
+    fn node_record_inner_0v1_display_works_1() {
+        let mut subject = make_node_record(1234, true);
+        subject.inner.accepts_connections = false;
+        subject.inner.routes_data = false;
+        subject.inner.version = 19;
+        subject.inner.country_code_opt = None;
+        subject.inner.earning_wallet = Wallet::from_str("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee").unwrap();
+        subject.inner.rate_pack = RatePack::new(100, 200, 300, 400);
+        let neighbor1 = PublicKey::new(&b"fiddle"[..]);
+        let neighbor2 = PublicKey::new(&b"diffle"[..]);
+        subject.inner.neighbors = vec![neighbor1, neighbor2]
+            .into_iter()
+            .collect::<BTreeSet<PublicKey>>();
+
+        let result = subject.inner.to_string();
+
+        assert_eq!(
+            result,
+            "ar v19 ZZ AQIDBA 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee 100|200|300|400 [ZGlmZmxl, ZmlkZGxl]".to_string()
+        )
+    }
+
+    #[test]
+    fn node_record_inner_0v1_display_works_2() {
+        let mut subject = make_node_record(2345, true);
+        subject.inner.accepts_connections = true;
+        subject.inner.routes_data = true;
+        subject.inner.version = 91;
+        subject.inner.country_code_opt = Some("US".to_string());
+        subject.inner.earning_wallet = Wallet::from_str("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee00").unwrap();
+        subject.inner.rate_pack = RatePack::new(400, 300, 200, 100);
+        subject.inner.neighbors = vec![]
+            .into_iter()
+            .collect::<BTreeSet<PublicKey>>();
+
+        let result = subject.inner.to_string();
+
+        assert_eq!(
+            result,
+            "AR v91 US AgMEBQ 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee00 400|300|200|100 []".to_string()
+        )
     }
 
     #[test]

--- a/node/src/neighborhood/overall_connection_status.rs
+++ b/node/src/neighborhood/overall_connection_status.rs
@@ -73,7 +73,7 @@ impl ConnectionProgress {
         let new_stage = usize::try_from(&connection_stage);
 
         if let (Ok(current_stage_num), Ok(new_stage_num)) = (current_stage, new_stage) {
-            if new_stage_num != current_stage_num + 1 {
+            if (new_stage_num != current_stage_num) && (new_stage_num != current_stage_num + 1) {
                 panic!(
                     "Can't update the stage from {:?} to {:?}",
                     self.connection_stage, connection_stage
@@ -341,6 +341,64 @@ mod tests {
     use masq_lib::messages::{ToMessageBody, UiConnectionChangeBroadcast, UiConnectionStage};
     use masq_lib::test_utils::logging::{init_test_logging, TestLogHandler};
     use masq_lib::ui_gateway::MessageTarget;
+
+    #[test]
+    fn update_stage_tolerates_advancement() {
+        let cases = vec![
+            (ConnectionStage::StageZero, ConnectionStage::TcpConnectionEstablished),
+            (ConnectionStage::TcpConnectionEstablished, ConnectionStage::NeighborshipEstablished),
+            (ConnectionStage::StageZero, ConnectionStage::Failed(TcpConnectionFailed)),
+            (ConnectionStage::TcpConnectionEstablished, ConnectionStage::Failed(PassLoopFound)),
+            (ConnectionStage::NeighborshipEstablished, ConnectionStage::Failed(NoGossipResponseReceived)),
+        ];
+        cases.into_iter().for_each(|(from_stage, to_stage)| {
+            let mut subject = ConnectionProgress {
+                initial_node_descriptor: make_node_descriptor(make_ip(1)),
+                current_peer_addr: make_ip(1),
+                connection_stage: from_stage,
+            };
+
+            subject.update_stage(&Logger::new("update_stage_tolerates_advancement"), to_stage.clone());
+
+            assert_eq!(subject.connection_stage, to_stage);
+        })
+    }
+
+    #[test]
+    #[should_panic(expected = "Can't update the stage from StageZero to NeighborshipEstablished")]
+    fn update_stage_does_not_tolerate_skipping() {
+        let mut subject = ConnectionProgress {
+            initial_node_descriptor: make_node_descriptor(make_ip(1)),
+            current_peer_addr: make_ip(1),
+            connection_stage: ConnectionStage::StageZero,
+        };
+
+        subject.update_stage(
+            &Logger::new("update_stage_does_not_tolerate_skipping"),
+            ConnectionStage::NeighborshipEstablished
+        );
+    }
+
+    #[test]
+    fn update_stage_tolerates_stasis() {
+        let cases = vec![
+            ConnectionStage::StageZero,
+            ConnectionStage::TcpConnectionEstablished,
+            ConnectionStage::NeighborshipEstablished,
+            ConnectionStage::Failed(TcpConnectionFailed),
+        ];
+        cases.into_iter().for_each(|stage| {
+            let mut subject = ConnectionProgress {
+                initial_node_descriptor: make_node_descriptor(make_ip(1)),
+                current_peer_addr: make_ip(1),
+                connection_stage: stage.clone(),
+            };
+
+            subject.update_stage(&Logger::new("update_stage_tolerates_stasis"), stage.clone());
+
+            assert_eq!(subject.connection_stage, stage);
+        })
+    }
 
     #[test]
     #[should_panic(

--- a/node/src/neighborhood/overall_connection_status.rs
+++ b/node/src/neighborhood/overall_connection_status.rs
@@ -345,11 +345,26 @@ mod tests {
     #[test]
     fn update_stage_tolerates_advancement() {
         let cases = vec![
-            (ConnectionStage::StageZero, ConnectionStage::TcpConnectionEstablished),
-            (ConnectionStage::TcpConnectionEstablished, ConnectionStage::NeighborshipEstablished),
-            (ConnectionStage::StageZero, ConnectionStage::Failed(TcpConnectionFailed)),
-            (ConnectionStage::TcpConnectionEstablished, ConnectionStage::Failed(PassLoopFound)),
-            (ConnectionStage::NeighborshipEstablished, ConnectionStage::Failed(NoGossipResponseReceived)),
+            (
+                ConnectionStage::StageZero,
+                ConnectionStage::TcpConnectionEstablished,
+            ),
+            (
+                ConnectionStage::TcpConnectionEstablished,
+                ConnectionStage::NeighborshipEstablished,
+            ),
+            (
+                ConnectionStage::StageZero,
+                ConnectionStage::Failed(TcpConnectionFailed),
+            ),
+            (
+                ConnectionStage::TcpConnectionEstablished,
+                ConnectionStage::Failed(PassLoopFound),
+            ),
+            (
+                ConnectionStage::NeighborshipEstablished,
+                ConnectionStage::Failed(NoGossipResponseReceived),
+            ),
         ];
         cases.into_iter().for_each(|(from_stage, to_stage)| {
             let mut subject = ConnectionProgress {
@@ -358,7 +373,10 @@ mod tests {
                 connection_stage: from_stage,
             };
 
-            subject.update_stage(&Logger::new("update_stage_tolerates_advancement"), to_stage.clone());
+            subject.update_stage(
+                &Logger::new("update_stage_tolerates_advancement"),
+                to_stage.clone(),
+            );
 
             assert_eq!(subject.connection_stage, to_stage);
         })
@@ -375,7 +393,7 @@ mod tests {
 
         subject.update_stage(
             &Logger::new("update_stage_does_not_tolerate_skipping"),
-            ConnectionStage::NeighborshipEstablished
+            ConnectionStage::NeighborshipEstablished,
         );
     }
 

--- a/node/src/node_configurator/unprivileged_parse_args_configuration.rs
+++ b/node/src/node_configurator/unprivileged_parse_args_configuration.rs
@@ -2496,7 +2496,7 @@ mod tests {
             .set_rate_pack_result(Ok(()))
             .rate_pack_limits_result(Ok(RatePackLimits::new(
                 RatePack::new(5, 5, 5, 5),
-                RatePack::new(7, 7, 7, 7)
+                RatePack::new(7, 7, 7, 7),
             )));
 
         let result = configure_rate_pack(
@@ -2531,7 +2531,7 @@ mod tests {
             .set_rate_pack_result(Ok(()))
             .rate_pack_limits_result(Ok(RatePackLimits::new(
                 RatePack::new(5, 5, 5, 5),
-                RatePack::new(7, 7, 7, 7)
+                RatePack::new(7, 7, 7, 7),
             )));
 
         let result = configure_rate_pack(

--- a/node/src/node_configurator/unprivileged_parse_args_configuration.rs
+++ b/node/src/node_configurator/unprivileged_parse_args_configuration.rs
@@ -556,12 +556,29 @@ fn configure_rate_pack(
     multi_config: &MultiConfig,
     persist_config: &mut dyn PersistentConfiguration,
 ) -> Result<RatePack, ConfiguratorError> {
-    let check_min_and_max = |candidate: u64, min: u64, max: u64, name: &str, error: ConfiguratorError| -> ConfiguratorError {
+    let check_min_and_max = |candidate: u64,
+                             min: u64,
+                             max: u64,
+                             name: &str,
+                             error: ConfiguratorError|
+     -> ConfiguratorError {
         let mut result = error;
         if candidate < min {
-            result = result.another_required("rate-pack", &format!("Value of {} ({}) is below the minimum allowed ({})", name, candidate, min));
+            result = result.another_required(
+                "rate-pack",
+                &format!(
+                    "Value of {} ({}) is below the minimum allowed ({})",
+                    name, candidate, min
+                ),
+            );
         } else if candidate > max {
-            result = result.another_required("rate-pack", &format!("Value of {} ({}) is above the maximum allowed ({})", name, candidate, max));
+            result = result.another_required(
+                "rate-pack",
+                &format!(
+                    "Value of {} ({}) is above the maximum allowed ({})",
+                    name, candidate, max
+                ),
+            );
         }
         result
     };
@@ -576,20 +593,43 @@ fn configure_rate_pack(
         Ok(rate_pack) => {
             let (low_limit, high_limit) = match persist_config.rate_pack_limits() {
                 Ok(pair) => pair,
-                Err(e) => return Err(e.into_configurator_error("rate-pack"))
+                Err(e) => return Err(e.into_configurator_error("rate-pack")),
             };
             let mut error = ConfiguratorError::new(vec![]);
-            error = check_min_and_max(rate_pack.routing_byte_rate, low_limit.routing_byte_rate, high_limit.routing_byte_rate, "routing_byte_rate", error);
-            error = check_min_and_max(rate_pack.routing_service_rate, low_limit.routing_service_rate, high_limit.routing_service_rate, "routing_service_rate", error);
-            error = check_min_and_max(rate_pack.exit_byte_rate, low_limit.exit_byte_rate, high_limit.exit_byte_rate, "exit_byte_rate", error);
-            error = check_min_and_max(rate_pack.exit_service_rate, low_limit.exit_service_rate, high_limit.exit_service_rate, "exit_service_rate", error);
-            if error.len() > 0 {
+            error = check_min_and_max(
+                rate_pack.routing_byte_rate,
+                low_limit.routing_byte_rate,
+                high_limit.routing_byte_rate,
+                "routing_byte_rate",
+                error,
+            );
+            error = check_min_and_max(
+                rate_pack.routing_service_rate,
+                low_limit.routing_service_rate,
+                high_limit.routing_service_rate,
+                "routing_service_rate",
+                error,
+            );
+            error = check_min_and_max(
+                rate_pack.exit_byte_rate,
+                low_limit.exit_byte_rate,
+                high_limit.exit_byte_rate,
+                "exit_byte_rate",
+                error,
+            );
+            error = check_min_and_max(
+                rate_pack.exit_service_rate,
+                low_limit.exit_service_rate,
+                high_limit.exit_service_rate,
+                "exit_service_rate",
+                error,
+            );
+            if !error.is_empty() {
                 Err(error)
-            }
-            else {
+            } else {
                 Ok(rate_pack)
             }
-        },
+        }
         Err(e) => Err(e),
     }
 }
@@ -2454,18 +2494,30 @@ mod tests {
         let mut persistent_config = PersistentConfigurationMock::new()
             .rate_pack_result(Ok(RatePack::new(0, 0, 0, 0)))
             .set_rate_pack_result(Ok(()))
-            .rate_pack_limits_result(Ok((
-                RatePack::new(5, 5, 5, 5),
-                RatePack::new(7, 7, 7, 7)
-            )));
+            .rate_pack_limits_result(Ok((RatePack::new(5, 5, 5, 5), RatePack::new(7, 7, 7, 7))));
 
-        let result = configure_rate_pack(&make_simplified_multi_config(["--rate-pack", "4|4|4|4"]), &mut persistent_config);
+        let result = configure_rate_pack(
+            &make_simplified_multi_config(["--rate-pack", "4|4|4|4"]),
+            &mut persistent_config,
+        );
 
         let expected_error = ConfiguratorError::new(vec![])
-            .another_required("rate-pack", "Value of routing_byte_rate (4) is below the minimum allowed (5)")
-            .another_required("rate-pack", "Value of routing_service_rate (4) is below the minimum allowed (5)")
-            .another_required("rate-pack", "Value of exit_byte_rate (4) is below the minimum allowed (5)")
-            .another_required("rate-pack", "Value of exit_service_rate (4) is below the minimum allowed (5)");
+            .another_required(
+                "rate-pack",
+                "Value of routing_byte_rate (4) is below the minimum allowed (5)",
+            )
+            .another_required(
+                "rate-pack",
+                "Value of routing_service_rate (4) is below the minimum allowed (5)",
+            )
+            .another_required(
+                "rate-pack",
+                "Value of exit_byte_rate (4) is below the minimum allowed (5)",
+            )
+            .another_required(
+                "rate-pack",
+                "Value of exit_service_rate (4) is below the minimum allowed (5)",
+            );
         assert_eq!(result, Err(expected_error));
     }
 
@@ -2474,18 +2526,30 @@ mod tests {
         let mut persistent_config = PersistentConfigurationMock::new()
             .rate_pack_result(Ok(RatePack::new(0, 0, 0, 0)))
             .set_rate_pack_result(Ok(()))
-            .rate_pack_limits_result(Ok((
-                RatePack::new(5, 5, 5, 5),
-                RatePack::new(7, 7, 7, 7)
-            )));
+            .rate_pack_limits_result(Ok((RatePack::new(5, 5, 5, 5), RatePack::new(7, 7, 7, 7))));
 
-        let result = configure_rate_pack(&make_simplified_multi_config(["--rate-pack", "8|8|8|8"]), &mut persistent_config);
+        let result = configure_rate_pack(
+            &make_simplified_multi_config(["--rate-pack", "8|8|8|8"]),
+            &mut persistent_config,
+        );
 
         let expected_error = ConfiguratorError::new(vec![])
-            .another_required("rate-pack", "Value of routing_byte_rate (8) is above the maximum allowed (7)")
-            .another_required("rate-pack", "Value of routing_service_rate (8) is above the maximum allowed (7)")
-            .another_required("rate-pack", "Value of exit_byte_rate (8) is above the maximum allowed (7)")
-            .another_required("rate-pack", "Value of exit_service_rate (8) is above the maximum allowed (7)");
+            .another_required(
+                "rate-pack",
+                "Value of routing_byte_rate (8) is above the maximum allowed (7)",
+            )
+            .another_required(
+                "rate-pack",
+                "Value of routing_service_rate (8) is above the maximum allowed (7)",
+            )
+            .another_required(
+                "rate-pack",
+                "Value of exit_byte_rate (8) is above the maximum allowed (7)",
+            )
+            .another_required(
+                "rate-pack",
+                "Value of exit_service_rate (8) is above the maximum allowed (7)",
+            );
         assert_eq!(result, Err(expected_error));
     }
 

--- a/node/src/node_configurator/unprivileged_parse_args_configuration.rs
+++ b/node/src/node_configurator/unprivileged_parse_args_configuration.rs
@@ -591,36 +591,36 @@ fn configure_rate_pack(
         |pc: &mut dyn PersistentConfiguration, rate_pack| pc.set_rate_pack(rate_pack),
     ) {
         Ok(rate_pack) => {
-            let (low_limit, high_limit) = match persist_config.rate_pack_limits() {
-                Ok(pair) => pair,
+            let rate_pack_limits = match persist_config.rate_pack_limits() {
+                Ok(rpl) => rpl,
                 Err(e) => return Err(e.into_configurator_error("rate-pack")),
             };
             let mut error = ConfiguratorError::new(vec![]);
             error = check_min_and_max(
                 rate_pack.routing_byte_rate,
-                low_limit.routing_byte_rate,
-                high_limit.routing_byte_rate,
+                rate_pack_limits.lo.routing_byte_rate,
+                rate_pack_limits.hi.routing_byte_rate,
                 "routing_byte_rate",
                 error,
             );
             error = check_min_and_max(
                 rate_pack.routing_service_rate,
-                low_limit.routing_service_rate,
-                high_limit.routing_service_rate,
+                rate_pack_limits.lo.routing_service_rate,
+                rate_pack_limits.hi.routing_service_rate,
                 "routing_service_rate",
                 error,
             );
             error = check_min_and_max(
                 rate_pack.exit_byte_rate,
-                low_limit.exit_byte_rate,
-                high_limit.exit_byte_rate,
+                rate_pack_limits.lo.exit_byte_rate,
+                rate_pack_limits.hi.exit_byte_rate,
                 "exit_byte_rate",
                 error,
             );
             error = check_min_and_max(
                 rate_pack.exit_service_rate,
-                low_limit.exit_service_rate,
-                high_limit.exit_service_rate,
+                rate_pack_limits.lo.exit_service_rate,
+                rate_pack_limits.hi.exit_service_rate,
                 "exit_service_rate",
                 error,
             );
@@ -694,7 +694,7 @@ mod tests {
     use crate::db_config::persistent_configuration::PersistentConfigurationReal;
     use crate::sub_lib::accountant::DEFAULT_PAYMENT_THRESHOLDS;
     use crate::sub_lib::cryptde::{PlainData, PublicKey};
-    use crate::sub_lib::neighborhood::{Hops, DEFAULT_RATE_PACK};
+    use crate::sub_lib::neighborhood::{Hops, RatePackLimits, DEFAULT_RATE_PACK};
     use crate::sub_lib::utils::make_new_multi_config;
     use crate::sub_lib::wallet::Wallet;
     use crate::test_utils::neighborhood_test_utils::MIN_HOPS_FOR_TEST;
@@ -2494,7 +2494,10 @@ mod tests {
         let mut persistent_config = PersistentConfigurationMock::new()
             .rate_pack_result(Ok(RatePack::new(0, 0, 0, 0)))
             .set_rate_pack_result(Ok(()))
-            .rate_pack_limits_result(Ok((RatePack::new(5, 5, 5, 5), RatePack::new(7, 7, 7, 7))));
+            .rate_pack_limits_result(Ok(RatePackLimits::new(
+                RatePack::new(5, 5, 5, 5),
+                RatePack::new(7, 7, 7, 7)
+            )));
 
         let result = configure_rate_pack(
             &make_simplified_multi_config(["--rate-pack", "4|4|4|4"]),
@@ -2526,7 +2529,10 @@ mod tests {
         let mut persistent_config = PersistentConfigurationMock::new()
             .rate_pack_result(Ok(RatePack::new(0, 0, 0, 0)))
             .set_rate_pack_result(Ok(()))
-            .rate_pack_limits_result(Ok((RatePack::new(5, 5, 5, 5), RatePack::new(7, 7, 7, 7))));
+            .rate_pack_limits_result(Ok(RatePackLimits::new(
+                RatePack::new(5, 5, 5, 5),
+                RatePack::new(7, 7, 7, 7)
+            )));
 
         let result = configure_rate_pack(
             &make_simplified_multi_config(["--rate-pack", "8|8|8|8"]),
@@ -2793,7 +2799,7 @@ mod tests {
             .past_neighbors_result(past_neighbors_result)
             .mapping_protocol_result(Ok(Some(AutomapProtocol::Pcp)))
             .rate_pack_result(Ok(rate_pack))
-            .rate_pack_limits_result(Ok((
+            .rate_pack_limits_result(Ok(RatePackLimits::new(
                 RatePack::new(u64::MIN, u64::MIN, u64::MIN, u64::MIN),
                 RatePack::new(u64::MAX, u64::MAX, u64::MAX, u64::MAX),
             )))

--- a/node/src/node_configurator/unprivileged_parse_args_configuration.rs
+++ b/node/src/node_configurator/unprivileged_parse_args_configuration.rs
@@ -305,6 +305,7 @@ fn make_neighborhood_mode(
             s
         ),
         None => {
+            // TODO: This default is now zero-hop rather than standard. This code should change.
             let rate_pack = configure_rate_pack(multi_config, persistent_config)?;
             neighborhood_mode_standard(multi_config, neighbor_configs, rate_pack)
         }

--- a/node/src/node_test_utils.rs
+++ b/node/src/node_test_utils.rs
@@ -6,11 +6,13 @@ use crate::discriminator::DiscriminatorFactory;
 use crate::discriminator::UnmaskedChunk;
 use crate::masquerader::MasqueradeError;
 use crate::masquerader::Masquerader;
+use crate::neighborhood::node_record::NodeRecord;
 use crate::node_configurator::DirsWrapper;
 use crate::null_masquerader::NullMasquerader;
 use crate::privilege_drop::IdWrapper;
 use crate::stream_handler_pool::StreamHandlerPoolSubs;
 use crate::stream_messages::*;
+use crate::sub_lib::cryptde::{CryptData, PlainData};
 use crate::sub_lib::framer::FramedChunk;
 use crate::sub_lib::framer::Framer;
 use crate::sub_lib::stream_handler_pool::DispatcherNodeQueryResponse;
@@ -315,5 +317,18 @@ impl Masquerader for FailingMasquerader {
         Err(MasqueradeError::LowLevelDataError(
             String::from_str("don't care").unwrap(),
         ))
+    }
+}
+
+impl NodeRecord {
+    pub fn but_no_node_addr(&self) -> NodeRecord {
+        let mut modified = NodeRecord {
+            inner: self.inner.clone(),
+            metadata: self.metadata.clone(),
+            signed_gossip: PlainData::new(&[]),
+            signature: CryptData::new(&[]),
+        };
+        modified.resign();
+        modified
     }
 }

--- a/node/src/stream_writer_sorted.rs
+++ b/node/src/stream_writer_sorted.rs
@@ -117,6 +117,7 @@ impl StreamWriterSorted {
                                 &packet.data.len(),
                                 &packet.sequence_number
                             );
+debug!(self.logger, "'{}'", String::from_utf8_lossy(&packet.data));
                             if len != packet.data.len() {
                                 debug!(
                                     self.logger,

--- a/node/src/stream_writer_sorted.rs
+++ b/node/src/stream_writer_sorted.rs
@@ -117,7 +117,7 @@ impl StreamWriterSorted {
                                 &packet.data.len(),
                                 &packet.sequence_number
                             );
-debug!(self.logger, "'{}'", String::from_utf8_lossy(&packet.data));
+                            debug!(self.logger, "'{}'", String::from_utf8_lossy(&packet.data));
                             if len != packet.data.len() {
                                 debug!(
                                     self.logger,

--- a/node/src/sub_lib/neighborhood.rs
+++ b/node/src/sub_lib/neighborhood.rs
@@ -48,6 +48,8 @@ pub const ZERO_RATE_PACK: RatePack = RatePack {
     exit_service_rate: 0,
 };
 
+pub const DEFAULT_RATE_PACK_LIMITS: &str = "100-100000000000000|100-100000000000000|100-100000000000000|100-100000000000000";
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct RatePack {
     pub routing_byte_rate: u64,
@@ -57,6 +59,20 @@ pub struct RatePack {
 }
 
 impl RatePack {
+    pub fn new(
+        routing_byte_rate: u64,
+        routing_service_rate: u64,
+        exit_byte_rate: u64,
+        exit_service_rate: u64,
+    ) -> Self {
+        Self {
+            routing_byte_rate,
+            routing_service_rate,
+            exit_byte_rate,
+            exit_service_rate,
+        }
+    }
+
     pub fn routing_charge(&self, payload_size: u64) -> u64 {
         self.routing_service_rate + (self.routing_byte_rate * payload_size)
     }

--- a/node/src/sub_lib/neighborhood.rs
+++ b/node/src/sub_lib/neighborhood.rs
@@ -23,6 +23,7 @@ use lazy_static::lazy_static;
 use masq_lib::blockchains::blockchain_records::CHAINS;
 use masq_lib::blockchains::chains::{chain_from_chain_identifier_opt, Chain};
 use masq_lib::constants::{CENTRAL_DELIMITER, CHAIN_IDENTIFIER_DELIMITER, MASQ_URL_PREFIX};
+use masq_lib::shared_schema::ConfiguratorError;
 use masq_lib::ui_gateway::NodeFromUiMessage;
 use masq_lib::utils::NeighborhoodModeLight;
 use serde_derive::{Deserialize, Serialize};
@@ -31,7 +32,6 @@ use std::fmt::{Debug, Display, Formatter};
 use std::net::IpAddr;
 use std::str::FromStr;
 use std::time::Duration;
-use masq_lib::shared_schema::ConfiguratorError;
 
 const ASK_ABOUT_GOSSIP_INTERVAL: Duration = Duration::from_secs(10);
 
@@ -87,7 +87,7 @@ impl RatePack {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RatePackLimits {
     pub lo: RatePack,
-    pub hi: RatePack
+    pub hi: RatePack,
 }
 
 impl RatePackLimits {
@@ -103,13 +103,12 @@ impl RatePackLimits {
     }
 
     pub fn analyze(&self, rate_pack: &RatePack) -> Result<(), ConfiguratorError> {
-        let check_min_and_max = |
-            candidate: u64,
-            min: u64,
-            max: u64,
-            name: &str,
-            error: ConfiguratorError
-        | -> ConfiguratorError {
+        let check_min_and_max = |candidate: u64,
+                                 min: u64,
+                                 max: u64,
+                                 name: &str,
+                                 error: ConfiguratorError|
+         -> ConfiguratorError {
             let mut result = error;
             if candidate < min {
                 result = result.another_required(

--- a/node/src/sub_lib/neighborhood.rs
+++ b/node/src/sub_lib/neighborhood.rs
@@ -175,7 +175,8 @@ impl RatePackLimits {
     }
 
     pub fn rate_pack_limits_parameter(&self) -> String {
-        format!("{}-{}|{}-{}|{}-{}|{}-{}",
+        format!(
+            "{}-{}|{}-{}|{}-{}|{}-{}",
             self.lo.routing_byte_rate,
             self.hi.routing_byte_rate,
             self.lo.routing_service_rate,
@@ -1026,8 +1027,10 @@ mod tests {
 
     #[test]
     fn from_str_complains_about_blank_public_key() {
-        let result =
-            NodeDescriptor::try_from((NB_CRYPTDE_PAIR.main.as_ref(), "masq://dev:@1.2.3.4:1234/2345"));
+        let result = NodeDescriptor::try_from((
+            NB_CRYPTDE_PAIR.main.as_ref(),
+            "masq://dev:@1.2.3.4:1234/2345",
+        ));
 
         assert_eq!(result, Err(String::from("Public key cannot be empty")));
     }

--- a/node/src/sub_lib/neighborhood.rs
+++ b/node/src/sub_lib/neighborhood.rs
@@ -48,7 +48,8 @@ pub const ZERO_RATE_PACK: RatePack = RatePack {
     exit_service_rate: 0,
 };
 
-pub const DEFAULT_RATE_PACK_LIMITS: &str = "100-100000000000000|100-100000000000000|100-100000000000000|100-100000000000000";
+pub const DEFAULT_RATE_PACK_LIMITS: &str =
+    "100-100000000000000|100-100000000000000|100-100000000000000|100-100000000000000";
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct RatePack {

--- a/node/src/sub_lib/neighborhood.rs
+++ b/node/src/sub_lib/neighborhood.rs
@@ -104,7 +104,6 @@ impl RatePack {
             self.exit_service_rate,
         )
     }
-
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/node/src/sub_lib/neighborhood.rs
+++ b/node/src/sub_lib/neighborhood.rs
@@ -94,6 +94,17 @@ impl RatePack {
     pub fn exit_charge(&self, payload_size: u64) -> u64 {
         self.exit_service_rate + (self.exit_byte_rate * payload_size)
     }
+
+    pub fn rate_pack_parameter(&self) -> String {
+        format!(
+            "{}|{}|{}|{}",
+            self.routing_byte_rate,
+            self.routing_service_rate,
+            self.exit_byte_rate,
+            self.exit_service_rate,
+        )
+    }
+
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/node/src/test_utils/database_utils.rs
+++ b/node/src/test_utils/database_utils.rs
@@ -18,6 +18,8 @@ use std::io::Read;
 use std::iter::once;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use crate::db_config::persistent_configuration::{PersistentConfiguration, PersistentConfigurationFactory};
+use crate::test_utils::persistent_configuration_mock::PersistentConfigurationMock;
 
 pub fn bring_db_0_back_to_life_and_return_connection(db_path: &Path) -> Connection {
     match remove_file(db_path) {
@@ -300,5 +302,21 @@ pub fn make_external_data() -> ExternalData {
         chain: TEST_DEFAULT_CHAIN,
         neighborhood_mode: NeighborhoodModeLight::Standard,
         db_password_opt: None,
+    }
+}
+
+pub struct PersistentConfigurationFactoryTest {
+    mock_opt: RefCell<Option<PersistentConfigurationMock>>
+}
+
+impl PersistentConfigurationFactory for PersistentConfigurationFactoryTest {
+    fn make(&self) -> Box<dyn PersistentConfiguration> {
+        Box::new(self.mock_opt.borrow_mut().take().expect("PersistentConfigurationFactoryTest already used"))
+    }
+}
+
+impl PersistentConfigurationFactoryTest {
+    pub fn new(mock: PersistentConfigurationMock) -> Self {
+        Self { mock_opt: RefCell::new(Some(mock)) }
     }
 }

--- a/node/src/test_utils/database_utils.rs
+++ b/node/src/test_utils/database_utils.rs
@@ -7,6 +7,10 @@ use crate::database::db_initializer::ExternalData;
 use crate::database::rusqlite_wrappers::ConnectionWrapper;
 
 use crate::database::db_migrations::db_migrator::DbMigrator;
+use crate::db_config::persistent_configuration::{
+    PersistentConfiguration, PersistentConfigurationFactory,
+};
+use crate::test_utils::persistent_configuration_mock::PersistentConfigurationMock;
 use masq_lib::logger::Logger;
 use masq_lib::test_utils::utils::TEST_DEFAULT_CHAIN;
 use masq_lib::utils::{to_string, NeighborhoodModeLight};
@@ -18,8 +22,6 @@ use std::io::Read;
 use std::iter::once;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use crate::db_config::persistent_configuration::{PersistentConfiguration, PersistentConfigurationFactory};
-use crate::test_utils::persistent_configuration_mock::PersistentConfigurationMock;
 
 pub fn bring_db_0_back_to_life_and_return_connection(db_path: &Path) -> Connection {
     match remove_file(db_path) {
@@ -306,17 +308,24 @@ pub fn make_external_data() -> ExternalData {
 }
 
 pub struct PersistentConfigurationFactoryTest {
-    mock_opt: RefCell<Option<PersistentConfigurationMock>>
+    mock_opt: RefCell<Option<PersistentConfigurationMock>>,
 }
 
 impl PersistentConfigurationFactory for PersistentConfigurationFactoryTest {
     fn make(&self) -> Box<dyn PersistentConfiguration> {
-        Box::new(self.mock_opt.borrow_mut().take().expect("PersistentConfigurationFactoryTest already used"))
+        Box::new(
+            self.mock_opt
+                .borrow_mut()
+                .take()
+                .expect("PersistentConfigurationFactoryTest already used"),
+        )
     }
 }
 
 impl PersistentConfigurationFactoryTest {
     pub fn new(mock: PersistentConfigurationMock) -> Self {
-        Self { mock_opt: RefCell::new(Some(mock)) }
+        Self {
+            mock_opt: RefCell::new(Some(mock)),
+        }
     }
 }

--- a/node/src/test_utils/mod.rs
+++ b/node/src/test_utils/mod.rs
@@ -507,7 +507,9 @@ pub mod unshared_test_utils {
     use crate::node_test_utils::DirsWrapperMock;
     use crate::sub_lib::accountant::{PaymentThresholds, ScanIntervals};
     use crate::sub_lib::cryptde::CryptDE;
-    use crate::sub_lib::neighborhood::{ConnectionProgressMessage, RatePack, RatePackLimits, DEFAULT_RATE_PACK};
+    use crate::sub_lib::neighborhood::{
+        ConnectionProgressMessage, RatePack, RatePackLimits, DEFAULT_RATE_PACK,
+    };
     use crate::sub_lib::proxy_client::ClientResponsePayload_0v1;
     use crate::sub_lib::proxy_server::{ClientRequestPayload_0v1, ProxyProtocol};
     use crate::sub_lib::sequence_buffer::SequencedPacket;

--- a/node/src/test_utils/mod.rs
+++ b/node/src/test_utils/mod.rs
@@ -633,7 +633,7 @@ pub mod unshared_test_utils {
         };
         let config = config.rate_pack_limits_result(Ok((
             RatePack::new(u64::MIN, u64::MIN, u64::MIN, u64::MIN),
-            RatePack::new(u64::MAX, u64::MAX, u64::MAX, u64::MAX)
+            RatePack::new(u64::MAX, u64::MAX, u64::MAX, u64::MAX),
         )));
         config
     }

--- a/node/src/test_utils/mod.rs
+++ b/node/src/test_utils/mod.rs
@@ -507,7 +507,7 @@ pub mod unshared_test_utils {
     use crate::node_test_utils::DirsWrapperMock;
     use crate::sub_lib::accountant::{PaymentThresholds, ScanIntervals};
     use crate::sub_lib::cryptde::CryptDE;
-    use crate::sub_lib::neighborhood::{ConnectionProgressMessage, RatePack, DEFAULT_RATE_PACK};
+    use crate::sub_lib::neighborhood::{ConnectionProgressMessage, RatePack, RatePackLimits, DEFAULT_RATE_PACK};
     use crate::sub_lib::proxy_client::ClientResponsePayload_0v1;
     use crate::sub_lib::proxy_server::{ClientRequestPayload_0v1, ProxyProtocol};
     use crate::sub_lib::sequence_buffer::SequencedPacket;
@@ -570,13 +570,13 @@ pub mod unshared_test_utils {
                 Either::Left((message_start, message_end)) => {
                     assert!(
                         panic_message_str.contains(message_start),
-                        "We expected this message {} to start with {}",
+                        "We expected this message '{}' to start with '{}'",
                         panic_message_str,
                         message_start
                     );
                     assert!(
                         panic_message_str.ends_with(message_end),
-                        "We expected this message {} to end with {}",
+                        "We expected this message '{}' to end with '{}'",
                         panic_message_str,
                         message_end
                     );
@@ -631,7 +631,7 @@ pub mod unshared_test_utils {
         } else {
             config
         };
-        let config = config.rate_pack_limits_result(Ok((
+        let config = config.rate_pack_limits_result(Ok(RatePackLimits::new(
             RatePack::new(u64::MIN, u64::MIN, u64::MIN, u64::MIN),
             RatePack::new(u64::MAX, u64::MAX, u64::MAX, u64::MAX),
         )));

--- a/node/src/test_utils/mod.rs
+++ b/node/src/test_utils/mod.rs
@@ -507,7 +507,7 @@ pub mod unshared_test_utils {
     use crate::node_test_utils::DirsWrapperMock;
     use crate::sub_lib::accountant::{PaymentThresholds, ScanIntervals};
     use crate::sub_lib::cryptde::CryptDE;
-    use crate::sub_lib::neighborhood::{ConnectionProgressMessage, DEFAULT_RATE_PACK};
+    use crate::sub_lib::neighborhood::{ConnectionProgressMessage, RatePack, DEFAULT_RATE_PACK};
     use crate::sub_lib::proxy_client::ClientResponsePayload_0v1;
     use crate::sub_lib::proxy_server::{ClientRequestPayload_0v1, ProxyProtocol};
     use crate::sub_lib::sequence_buffer::SequencedPacket;
@@ -631,6 +631,10 @@ pub mod unshared_test_utils {
         } else {
             config
         };
+        let config = config.rate_pack_limits_result(Ok((
+            RatePack::new(u64::MIN, u64::MIN, u64::MIN, u64::MIN),
+            RatePack::new(u64::MAX, u64::MAX, u64::MAX, u64::MAX)
+        )));
         config
     }
 

--- a/node/src/test_utils/persistent_configuration_mock.rs
+++ b/node/src/test_utils/persistent_configuration_mock.rs
@@ -76,6 +76,7 @@ pub struct PersistentConfigurationMock {
     set_payment_thresholds_params: Arc<Mutex<Vec<String>>>,
     set_payment_thresholds_results: RefCell<Vec<Result<(), PersistentConfigError>>>,
     rate_pack_results: RefCell<Vec<Result<RatePack, PersistentConfigError>>>,
+    rate_pack_limits_results: RefCell<Vec<Result<(RatePack, RatePack), PersistentConfigError>>>,
     set_rate_pack_params: Arc<Mutex<Vec<String>>>,
     set_rate_pack_results: RefCell<Vec<Result<(), PersistentConfigError>>>,
     scan_intervals_results: RefCell<Vec<Result<ScanIntervals, PersistentConfigError>>>,
@@ -152,6 +153,7 @@ impl Clone for PersistentConfigurationMock {
             set_payment_thresholds_params: self.set_payment_thresholds_params.clone(),
             set_payment_thresholds_results: self.set_payment_thresholds_results.clone(),
             rate_pack_results: self.rate_pack_results.clone(),
+            rate_pack_limits_results: self.rate_pack_limits_results.clone(),
             set_rate_pack_params: self.set_rate_pack_params.clone(),
             set_rate_pack_results: self.set_rate_pack_results.clone(),
             scan_intervals_results: self.scan_intervals_results.clone(),
@@ -400,6 +402,10 @@ impl PersistentConfiguration for PersistentConfigurationMock {
     fn set_rate_pack(&mut self, rate_pack: String) -> Result<(), PersistentConfigError> {
         self.set_rate_pack_params.lock().unwrap().push(rate_pack);
         self.set_rate_pack_results.borrow_mut().remove(0)
+    }
+
+    fn rate_pack_limits(&self) -> Result<(RatePack, RatePack), PersistentConfigError> {
+        self.rate_pack_limits_results.borrow_mut().remove(0)
     }
 
     fn scan_intervals(&self) -> Result<ScanIntervals, PersistentConfigError> {
@@ -756,6 +762,11 @@ impl PersistentConfigurationMock {
 
     pub fn rate_pack_result(self, result: Result<RatePack, PersistentConfigError>) -> Self {
         self.rate_pack_results.borrow_mut().push(result);
+        self
+    }
+
+    pub fn rate_pack_limits_result(self, result: Result<(RatePack, RatePack), PersistentConfigError>) -> Self {
+        self.rate_pack_limits_results.borrow_mut().push(result);
         self
     }
 

--- a/node/src/test_utils/persistent_configuration_mock.rs
+++ b/node/src/test_utils/persistent_configuration_mock.rs
@@ -765,7 +765,10 @@ impl PersistentConfigurationMock {
         self
     }
 
-    pub fn rate_pack_limits_result(self, result: Result<(RatePack, RatePack), PersistentConfigError>) -> Self {
+    pub fn rate_pack_limits_result(
+        self,
+        result: Result<(RatePack, RatePack), PersistentConfigError>,
+    ) -> Self {
         self.rate_pack_limits_results.borrow_mut().push(result);
         self
     }

--- a/node/src/test_utils/persistent_configuration_mock.rs
+++ b/node/src/test_utils/persistent_configuration_mock.rs
@@ -6,7 +6,7 @@ use crate::database::rusqlite_wrappers::TransactionSafeWrapper;
 use crate::db_config::persistent_configuration::{PersistentConfigError, PersistentConfiguration};
 use crate::sub_lib::accountant::{PaymentThresholds, ScanIntervals};
 use crate::sub_lib::cryptde::CryptDE;
-use crate::sub_lib::neighborhood::{Hops, NodeDescriptor, RatePack};
+use crate::sub_lib::neighborhood::{Hops, NodeDescriptor, RatePack, RatePackLimits};
 use crate::sub_lib::wallet::Wallet;
 use crate::test_utils::unshared_test_utils::arbitrary_id_stamp::ArbitraryIdStamp;
 use crate::{arbitrary_id_stamp_in_trait_impl, set_arbitrary_id_stamp_in_mock_impl};
@@ -76,7 +76,7 @@ pub struct PersistentConfigurationMock {
     set_payment_thresholds_params: Arc<Mutex<Vec<String>>>,
     set_payment_thresholds_results: RefCell<Vec<Result<(), PersistentConfigError>>>,
     rate_pack_results: RefCell<Vec<Result<RatePack, PersistentConfigError>>>,
-    rate_pack_limits_results: RefCell<Vec<Result<(RatePack, RatePack), PersistentConfigError>>>,
+    rate_pack_limits_results: RefCell<Vec<Result<RatePackLimits, PersistentConfigError>>>,
     set_rate_pack_params: Arc<Mutex<Vec<String>>>,
     set_rate_pack_results: RefCell<Vec<Result<(), PersistentConfigError>>>,
     scan_intervals_results: RefCell<Vec<Result<ScanIntervals, PersistentConfigError>>>,
@@ -404,7 +404,7 @@ impl PersistentConfiguration for PersistentConfigurationMock {
         self.set_rate_pack_results.borrow_mut().remove(0)
     }
 
-    fn rate_pack_limits(&self) -> Result<(RatePack, RatePack), PersistentConfigError> {
+    fn rate_pack_limits(&self) -> Result<RatePackLimits, PersistentConfigError> {
         self.rate_pack_limits_results.borrow_mut().remove(0)
     }
 
@@ -767,7 +767,7 @@ impl PersistentConfigurationMock {
 
     pub fn rate_pack_limits_result(
         self,
-        result: Result<(RatePack, RatePack), PersistentConfigError>,
+        result: Result<RatePackLimits, PersistentConfigError>,
     ) -> Self {
         self.rate_pack_limits_results.borrow_mut().push(result);
         self


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces bounded rate packs and migrates configuration/storage accordingly.
> 
> - Adds `rate_pack_limits` to config with parsing/validation and accessors; implements `PersistentConfigurationFactory` and an `Invalid` placeholder
> - New DB migration `11→12` inserts default `rate_pack_limits`; bumps `CURRENT_SCHEMA_VERSION` to `12`
> - Updates setup/tests to higher `rate-pack` values; adjusts UI/setup, config DAO, and initializer to surface defaults
> - Refactors accountant charge handling (precompute `total_charge`) and clarifies debug logs; updates unit tests
> - Multinode test robustness: retry Docker network creation, longer timeouts/sleeps, more nodes; switches HTTP checks to testingmcafeesites.com
> - Minor API/UX tweaks: `NodeRenderable` field rename, `AccessibleGossipRecord` Display/formatting, add `agrs_to_string`; enable `time` crate `local-offset` feature
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9313296d9b7165dcc87b2d9955a574c858b6bb77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->