### PR TITLE
GH-754: Gas Price Optimisation - Hot Fix

### DIFF
--- a/masq_lib/src/constants.rs
+++ b/masq_lib/src/constants.rs
@@ -84,6 +84,7 @@ pub const MASQ_TOTAL_SUPPLY: u64 = 37_500_000;
 
 pub const DEFAULT_GAS_PRICE: u64 = 1; //TODO ?? Really
 pub const DEFAULT_GAS_PRICE_MARGIN: u64 = 30;
+pub const DEFAULT_GAS_PRICE_RETRY_CONSTANT: u128 = 5_000; // TODO: GH-827: Test Me
 pub const DEFAULT_MAX_BLOCK_COUNT: u64 = 100_000;
 
 //chains

--- a/masq_lib/src/constants.rs
+++ b/masq_lib/src/constants.rs
@@ -83,8 +83,8 @@ pub const VALUE_EXCEEDS_ALLOWED_LIMIT: u64 = ACCOUNTANT_PREFIX | 3;
 pub const MASQ_TOTAL_SUPPLY: u64 = 37_500_000;
 
 pub const DEFAULT_GAS_PRICE: u64 = 1; //TODO ?? Really
-pub const DEFAULT_GAS_PRICE_MARGIN: u64 = 30;
-pub const DEFAULT_GAS_PRICE_RETRY_CONSTANT: u128 = 5_000; // TODO: GH-827: Test Me
+pub const DEFAULT_GAS_PRICE_RETRY_PERCENTAGE: u64 = 30;
+pub const DEFAULT_GAS_PRICE_RETRY_CONSTANT: u128 = 5_000;
 pub const DEFAULT_MAX_BLOCK_COUNT: u64 = 100_000;
 
 //chains
@@ -143,7 +143,8 @@ mod tests {
         assert_eq!(CURRENT_LOGFILE_NAME, "MASQNode_rCURRENT.log");
         assert_eq!(MASQ_PROMPT, "masq> ");
         assert_eq!(DEFAULT_GAS_PRICE, 1);
-        assert_eq!(DEFAULT_GAS_PRICE_MARGIN, 30);
+        assert_eq!(DEFAULT_GAS_PRICE_RETRY_PERCENTAGE, 30);
+        assert_eq!(DEFAULT_GAS_PRICE_RETRY_CONSTANT, 5_000);
         assert_eq!(WALLET_ADDRESS_LENGTH, 42);
         assert_eq!(MASQ_TOTAL_SUPPLY, 37_500_000);
         assert_eq!(WEIS_IN_GWEI, 1_000_000_000);

--- a/node/src/accountant/scanners/payable_scanner/tx_templates/priced/new.rs
+++ b/node/src/accountant/scanners/payable_scanner/tx_templates/priced/new.rs
@@ -4,7 +4,7 @@ use crate::accountant::scanners::payable_scanner::tx_templates::initial::new::{
     NewTxTemplate, NewTxTemplates,
 };
 use crate::accountant::scanners::payable_scanner::tx_templates::BaseTxTemplate;
-use crate::blockchain::blockchain_bridge::increase_gas_price_by_margin;
+use crate::blockchain::blockchain_bridge::increase_by_percentage;
 use masq_lib::logger::Logger;
 use std::ops::Deref;
 use thousands::Separable;
@@ -63,7 +63,7 @@ impl PricedNewTxTemplates {
         ceil: u128,
         logger: &Logger,
     ) -> Self {
-        let computed_gas_price_wei = increase_gas_price_by_margin(latest_gas_price_wei);
+        let computed_gas_price_wei = increase_by_percentage(latest_gas_price_wei);
 
         let safe_gas_price_wei = if computed_gas_price_wei > ceil {
             warning!(

--- a/node/src/accountant/scanners/payable_scanner/tx_templates/priced/retry.rs
+++ b/node/src/accountant/scanners/payable_scanner/tx_templates/priced/retry.rs
@@ -4,7 +4,7 @@ use crate::accountant::scanners::payable_scanner::tx_templates::initial::retry::
     RetryTxTemplate, RetryTxTemplates,
 };
 use crate::accountant::scanners::payable_scanner::tx_templates::BaseTxTemplate;
-use crate::blockchain::blockchain_bridge::increase_gas_price_by_margin;
+use crate::blockchain::blockchain_bridge::increase_by_percentage;
 use masq_lib::constants::DEFAULT_GAS_PRICE_RETRY_CONSTANT;
 use masq_lib::logger::Logger;
 use std::ops::{Deref, DerefMut};
@@ -49,7 +49,7 @@ impl PricedRetryTxTemplate {
 
     fn compute_gas_price(latest_gas_price_wei: u128, prev_gas_price_wei: u128) -> u128 {
         if latest_gas_price_wei >= prev_gas_price_wei {
-            increase_gas_price_by_margin(latest_gas_price_wei)
+            increase_by_percentage(latest_gas_price_wei)
         } else {
             prev_gas_price_wei + DEFAULT_GAS_PRICE_RETRY_CONSTANT
         }
@@ -183,7 +183,7 @@ mod tests {
         let computed_gas_price =
             PricedRetryTxTemplate::compute_gas_price(latest_gas_price_wei, prev_gas_price_wei);
 
-        let expected_gas_price = increase_gas_price_by_margin(latest_gas_price_wei);
+        let expected_gas_price = increase_by_percentage(latest_gas_price_wei);
         assert_eq!(computed_gas_price, expected_gas_price);
     }
 
@@ -207,7 +207,7 @@ mod tests {
         let computed_gas_price =
             PricedRetryTxTemplate::compute_gas_price(latest_gas_price_wei, prev_gas_price_wei);
 
-        let expected_gas_price = increase_gas_price_by_margin(latest_gas_price_wei);
+        let expected_gas_price = increase_by_percentage(latest_gas_price_wei);
         assert_eq!(computed_gas_price, expected_gas_price);
     }
 }

--- a/node/src/accountant/scanners/payable_scanner/tx_templates/priced/retry.rs
+++ b/node/src/accountant/scanners/payable_scanner/tx_templates/priced/retry.rs
@@ -47,6 +47,13 @@ impl PricedRetryTxTemplate {
     }
 
     fn compute_gas_price(latest_gas_price_wei: u128, prev_gas_price_wei: u128) -> u128 {
+        // TODO: GH-827: Test Me and Make me alive
+        // if latest_gas_price_wei >= prev_gas_price_wei {
+        //     increase_gas_price_by_margin(latest_gas_price_wei)
+        // } else {
+        //     prev_gas_price_wei + 1
+        // }
+
         let gas_price_wei = latest_gas_price_wei.max(prev_gas_price_wei);
 
         increase_gas_price_by_margin(gas_price_wei)

--- a/node/src/accountant/scanners/payable_scanner/tx_templates/priced/retry.rs
+++ b/node/src/accountant/scanners/payable_scanner/tx_templates/priced/retry.rs
@@ -176,8 +176,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn compute_gas_price_increases_by_percentage_if_latest_if_higher() {
-        let latest_gas_price_wei = 120;
+    fn compute_gas_price_increases_by_percentage_if_latest_is_higher() {
+        let latest_gas_price_wei = 101;
+        let prev_gas_price_wei = 100;
+
+        let computed_gas_price =
+            PricedRetryTxTemplate::compute_gas_price(latest_gas_price_wei, prev_gas_price_wei);
+
+        let expected_gas_price = increase_by_percentage(latest_gas_price_wei);
+        assert_eq!(computed_gas_price, expected_gas_price);
+    }
+
+    #[test]
+    fn compute_gas_price_increases_by_percentage_if_latest_is_equal() {
+        let latest_gas_price_wei = 100;
         let prev_gas_price_wei = 100;
 
         let computed_gas_price =
@@ -189,25 +201,13 @@ mod tests {
 
     #[test]
     fn compute_gas_price_increments_previous_by_constant_if_latest_is_lower() {
-        let latest_gas_price_wei = 80;
+        let latest_gas_price_wei = 99;
         let prev_gas_price_wei = 100;
 
         let computed_gas_price =
             PricedRetryTxTemplate::compute_gas_price(latest_gas_price_wei, prev_gas_price_wei);
 
         let expected_gas_price = prev_gas_price_wei + DEFAULT_GAS_PRICE_RETRY_CONSTANT;
-        assert_eq!(computed_gas_price, expected_gas_price);
-    }
-
-    #[test]
-    fn compute_gas_price_increases_by_percentage_if_latest_if_equal() {
-        let latest_gas_price_wei = 100;
-        let prev_gas_price_wei = 100;
-
-        let computed_gas_price =
-            PricedRetryTxTemplate::compute_gas_price(latest_gas_price_wei, prev_gas_price_wei);
-
-        let expected_gas_price = increase_by_percentage(latest_gas_price_wei);
         assert_eq!(computed_gas_price, expected_gas_price);
     }
 }

--- a/node/src/accountant/scanners/payable_scanner/tx_templates/priced/retry.rs
+++ b/node/src/accountant/scanners/payable_scanner/tx_templates/priced/retry.rs
@@ -5,6 +5,7 @@ use crate::accountant::scanners::payable_scanner::tx_templates::initial::retry::
 };
 use crate::accountant::scanners::payable_scanner::tx_templates::BaseTxTemplate;
 use crate::blockchain::blockchain_bridge::increase_gas_price_by_margin;
+use masq_lib::constants::DEFAULT_GAS_PRICE_RETRY_CONSTANT;
 use masq_lib::logger::Logger;
 use std::ops::{Deref, DerefMut};
 use thousands::Separable;
@@ -47,16 +48,11 @@ impl PricedRetryTxTemplate {
     }
 
     fn compute_gas_price(latest_gas_price_wei: u128, prev_gas_price_wei: u128) -> u128 {
-        // TODO: GH-827: Test Me and Make me alive
-        // if latest_gas_price_wei >= prev_gas_price_wei {
-        //     increase_gas_price_by_margin(latest_gas_price_wei)
-        // } else {
-        //     prev_gas_price_wei + 1
-        // }
-
-        let gas_price_wei = latest_gas_price_wei.max(prev_gas_price_wei);
-
-        increase_gas_price_by_margin(gas_price_wei)
+        if latest_gas_price_wei >= prev_gas_price_wei {
+            increase_gas_price_by_margin(latest_gas_price_wei)
+        } else {
+            prev_gas_price_wei + DEFAULT_GAS_PRICE_RETRY_CONSTANT
+        }
     }
 }
 
@@ -172,5 +168,46 @@ impl RetryLogBuilder {
                 )
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_gas_price_increases_by_percentage_if_latest_if_higher() {
+        let latest_gas_price_wei = 120;
+        let prev_gas_price_wei = 100;
+
+        let computed_gas_price =
+            PricedRetryTxTemplate::compute_gas_price(latest_gas_price_wei, prev_gas_price_wei);
+
+        let expected_gas_price = increase_gas_price_by_margin(latest_gas_price_wei);
+        assert_eq!(computed_gas_price, expected_gas_price);
+    }
+
+    #[test]
+    fn compute_gas_price_increments_previous_by_constant_if_latest_is_lower() {
+        let latest_gas_price_wei = 80;
+        let prev_gas_price_wei = 100;
+
+        let computed_gas_price =
+            PricedRetryTxTemplate::compute_gas_price(latest_gas_price_wei, prev_gas_price_wei);
+
+        let expected_gas_price = prev_gas_price_wei + DEFAULT_GAS_PRICE_RETRY_CONSTANT;
+        assert_eq!(computed_gas_price, expected_gas_price);
+    }
+
+    #[test]
+    fn compute_gas_price_increases_by_percentage_if_latest_if_equal() {
+        let latest_gas_price_wei = 100;
+        let prev_gas_price_wei = 100;
+
+        let computed_gas_price =
+            PricedRetryTxTemplate::compute_gas_price(latest_gas_price_wei, prev_gas_price_wei);
+
+        let expected_gas_price = increase_gas_price_by_margin(latest_gas_price_wei);
+        assert_eq!(computed_gas_price, expected_gas_price);
     }
 }

--- a/node/src/accountant/scanners/payable_scanner/tx_templates/priced/retry.rs
+++ b/node/src/accountant/scanners/payable_scanner/tx_templates/priced/retry.rs
@@ -35,7 +35,7 @@ impl PricedRetryTxTemplate {
     ) -> PricedRetryTxTemplate {
         let receiver = retry_tx_template.base.receiver_address;
         let computed_gas_price_wei =
-            Self::compute_gas_price(retry_tx_template.prev_gas_price_wei, latest_gas_price_wei);
+            Self::compute_gas_price(latest_gas_price_wei, retry_tx_template.prev_gas_price_wei);
 
         let safe_gas_price_wei = if computed_gas_price_wei > ceil {
             log_builder.push(receiver, computed_gas_price_wei);
@@ -47,7 +47,7 @@ impl PricedRetryTxTemplate {
         PricedRetryTxTemplate::new(retry_tx_template, safe_gas_price_wei)
     }
 
-    fn compute_gas_price(latest_gas_price_wei: u128, prev_gas_price_wei: u128) -> u128 {
+    pub fn compute_gas_price(latest_gas_price_wei: u128, prev_gas_price_wei: u128) -> u128 {
         if latest_gas_price_wei >= prev_gas_price_wei {
             increase_by_percentage(latest_gas_price_wei)
         } else {

--- a/node/src/blockchain/blockchain_agent/agent_web3.rs
+++ b/node/src/blockchain/blockchain_agent/agent_web3.rs
@@ -392,17 +392,17 @@ mod tests {
         let account_1 = make_payable_account(12);
         let account_2 = make_payable_account(34);
         let ceiling_gas_price_wei = chain.rec().gas_price_safe_ceiling_minor;
-        // This should be the value that would surplus the ceiling just slightly if the margin is applied
-        let border_gas_price_wei = ceiling_gas_price_wei - DEFAULT_GAS_PRICE_RETRY_CONSTANT + 1;
-        let rpc_gas_price_wei = border_gas_price_wei - 1;
-        let check_value_wei = increase_by_percentage(border_gas_price_wei);
+        // Once the gas price is computed from latest and prev gas price values, it'll break the ceiling
+        let prev_gas_price_wei = ceiling_gas_price_wei + 1 - DEFAULT_GAS_PRICE_RETRY_CONSTANT;
+        let latest_gas_price_wei = prev_gas_price_wei - 100; // Any value lower than prev will work
+        let check_value_wei = increase_by_percentage(prev_gas_price_wei);
         let template_1 = RetryTxTemplateBuilder::new()
             .payable_account(&account_1)
-            .prev_gas_price_wei(border_gas_price_wei)
+            .prev_gas_price_wei(prev_gas_price_wei)
             .build();
         let template_2 = RetryTxTemplateBuilder::new()
             .payable_account(&account_2)
-            .prev_gas_price_wei(border_gas_price_wei)
+            .prev_gas_price_wei(prev_gas_price_wei)
             .build();
         let retry_tx_templates = vec![template_1, template_2];
         let expected_log_msg = format!(
@@ -415,7 +415,7 @@ mod tests {
         test_gas_price_must_not_break_through_ceiling_value_in_the_retry_payable_mode(
             test_name,
             chain,
-            rpc_gas_price_wei,
+            latest_gas_price_wei,
             Either::Right(RetryTxTemplates(retry_tx_templates)),
             &expected_log_msg,
         );

--- a/node/src/blockchain/blockchain_agent/agent_web3.rs
+++ b/node/src/blockchain/blockchain_agent/agent_web3.rs
@@ -611,30 +611,32 @@ mod tests {
     fn estimate_transaction_fee_total_works_for_retry_txs() {
         let consuming_wallet = make_wallet("efg");
         let consuming_wallet_balances = make_zeroed_consuming_wallet_balances();
-        let rpc_gas_price_wei = 444_555_666;
+        let latest_gas_price_wei = 444_555_666;
         let chain = TEST_DEFAULT_CHAIN;
+        let prev_gas_prices = vec![
+            latest_gas_price_wei - 1,
+            latest_gas_price_wei,
+            latest_gas_price_wei + 1,
+            latest_gas_price_wei - 123_456,
+            latest_gas_price_wei + 456_789,
+        ];
         let retry_tx_templates: Vec<RetryTxTemplate> = {
-            vec![
-                rpc_gas_price_wei - 1,
-                rpc_gas_price_wei,
-                rpc_gas_price_wei + 1,
-                rpc_gas_price_wei - 123_456,
-                rpc_gas_price_wei + 456_789,
-            ]
-            .into_iter()
-            .enumerate()
-            .map(|(idx, prev_gas_price_wei)| {
-                let account = make_payable_account((idx as u64 + 1) * 3_000);
-                RetryTxTemplate {
-                    base: BaseTxTemplate::from(&account),
-                    prev_gas_price_wei,
-                    prev_nonce: idx as u64,
-                }
-            })
-            .collect()
+            prev_gas_prices
+                .clone()
+                .into_iter()
+                .enumerate()
+                .map(|(idx, prev_gas_price_wei)| {
+                    let account = make_payable_account((idx as u64 + 1) * 3_000);
+                    RetryTxTemplate {
+                        base: BaseTxTemplate::from(&account),
+                        prev_gas_price_wei,
+                        prev_nonce: idx as u64,
+                    }
+                })
+                .collect()
         };
         let subject = BlockchainAgentWeb3::new(
-            rpc_gas_price_wei,
+            latest_gas_price_wei,
             77_777,
             consuming_wallet,
             consuming_wallet_balances,
@@ -645,18 +647,11 @@ mod tests {
 
         let result = subject.estimate_transaction_fee_total(&priced_qualified_payables);
 
-        let gas_prices_for_accounts_from_1_to_5 = vec![
-            PricedRetryTxTemplate::compute_gas_price(rpc_gas_price_wei, rpc_gas_price_wei - 1),
-            PricedRetryTxTemplate::compute_gas_price(rpc_gas_price_wei, rpc_gas_price_wei),
-            PricedRetryTxTemplate::compute_gas_price(rpc_gas_price_wei, rpc_gas_price_wei + 1),
-            PricedRetryTxTemplate::compute_gas_price(rpc_gas_price_wei, rpc_gas_price_wei),
-            PricedRetryTxTemplate::compute_gas_price(
-                rpc_gas_price_wei,
-                rpc_gas_price_wei + 456_789,
-            ),
-        ];
-        let expected_result = gas_prices_for_accounts_from_1_to_5
+        let expected_result = prev_gas_prices
             .into_iter()
+            .map(|prev_gas_price_wei| {
+                PricedRetryTxTemplate::compute_gas_price(latest_gas_price_wei, prev_gas_price_wei)
+            })
             .sum::<u128>()
             * (77_777 + WEB3_MAXIMAL_GAS_LIMIT_MARGIN);
         assert_eq!(result, expected_result)

--- a/node/src/blockchain/blockchain_agent/agent_web3.rs
+++ b/node/src/blockchain/blockchain_agent/agent_web3.rs
@@ -122,7 +122,9 @@ mod tests {
     use crate::test_utils::make_wallet;
     use itertools::{Either, Itertools};
     use masq_lib::blockchains::chains::Chain;
-    use masq_lib::constants::DEFAULT_GAS_PRICE_RETRY_PERCENTAGE;
+    use masq_lib::constants::{
+        DEFAULT_GAS_PRICE_RETRY_CONSTANT, DEFAULT_GAS_PRICE_RETRY_PERCENTAGE,
+    };
     use masq_lib::logger::Logger;
     use masq_lib::test_utils::logging::{init_test_logging, TestLogHandler};
     use masq_lib::test_utils::utils::TEST_DEFAULT_CHAIN;
@@ -391,8 +393,7 @@ mod tests {
         let account_2 = make_payable_account(34);
         let ceiling_gas_price_wei = chain.rec().gas_price_safe_ceiling_minor;
         // This should be the value that would surplus the ceiling just slightly if the margin is applied
-        let border_gas_price_wei =
-            (ceiling_gas_price_wei * 100) / (DEFAULT_GAS_PRICE_RETRY_PERCENTAGE as u128 + 100) + 2;
+        let border_gas_price_wei = ceiling_gas_price_wei - DEFAULT_GAS_PRICE_RETRY_CONSTANT + 1;
         let rpc_gas_price_wei = border_gas_price_wei - 1;
         let check_value_wei = increase_by_percentage(border_gas_price_wei);
         let template_1 = RetryTxTemplateBuilder::new()
@@ -474,8 +475,8 @@ mod tests {
         let expected_log_msg = format!(
             "The computed gas price(s) in wei is above the ceil value of 50,000,000,000 wei computed by this Node.\n\
              Transaction(s) to following receivers are affected:\n\
-             0x00000000000000000000000077616c6c65743132 with gas price 64,999,999,998\n\
-             0x00000000000000000000000077616c6c65743334 with gas price 64,999,999,997"
+             0x00000000000000000000000077616c6c65743132 with gas price 50,000,004,999\n\
+             0x00000000000000000000000077616c6c65743334 with gas price 50,000,004,998"
         );
 
         test_gas_price_must_not_break_through_ceiling_value_in_the_retry_payable_mode(

--- a/node/src/blockchain/blockchain_agent/agent_web3.rs
+++ b/node/src/blockchain/blockchain_agent/agent_web3.rs
@@ -118,11 +118,11 @@ mod tests {
         BlockchainAgentWeb3, WEB3_MAXIMAL_GAS_LIMIT_MARGIN,
     };
     use crate::blockchain::blockchain_agent::BlockchainAgent;
-    use crate::blockchain::blockchain_bridge::increase_gas_price_by_margin;
+    use crate::blockchain::blockchain_bridge::increase_by_percentage;
     use crate::test_utils::make_wallet;
     use itertools::{Either, Itertools};
     use masq_lib::blockchains::chains::Chain;
-    use masq_lib::constants::DEFAULT_GAS_PRICE_MARGIN;
+    use masq_lib::constants::DEFAULT_GAS_PRICE_RETRY_PERCENTAGE;
     use masq_lib::logger::Logger;
     use masq_lib::test_utils::logging::{init_test_logging, TestLogHandler};
     use masq_lib::test_utils::utils::TEST_DEFAULT_CHAIN;
@@ -155,7 +155,7 @@ mod tests {
 
         let result = subject.price_qualified_payables(Either::Left(new_tx_templates.clone()));
 
-        let gas_price_with_margin_wei = increase_gas_price_by_margin(rpc_gas_price_wei);
+        let gas_price_with_margin_wei = increase_by_percentage(rpc_gas_price_wei);
         let expected_result = Either::Left(PricedNewTxTemplates::new(
             new_tx_templates,
             gas_price_with_margin_wei,
@@ -206,11 +206,11 @@ mod tests {
 
         let expected_result = {
             let price_wei_for_accounts_from_1_to_5 = vec![
-                increase_gas_price_by_margin(rpc_gas_price_wei),
-                increase_gas_price_by_margin(rpc_gas_price_wei),
-                increase_gas_price_by_margin(rpc_gas_price_wei + 1),
-                increase_gas_price_by_margin(rpc_gas_price_wei),
-                increase_gas_price_by_margin(rpc_gas_price_wei + 456_789),
+                increase_by_percentage(rpc_gas_price_wei),
+                increase_by_percentage(rpc_gas_price_wei),
+                increase_by_percentage(rpc_gas_price_wei + 1),
+                increase_by_percentage(rpc_gas_price_wei),
+                increase_by_percentage(rpc_gas_price_wei + 456_789),
             ];
             if price_wei_for_accounts_from_1_to_5.len() != retry_tx_templates.len() {
                 panic!("Corrupted test")
@@ -238,9 +238,10 @@ mod tests {
         // This should be the value that would surplus the ceiling just slightly if the margin is
         // applied.
         // Adding just 1 didn't work, therefore 2
-        let rpc_gas_price_wei =
-            ((ceiling_gas_price_wei * 100) / (DEFAULT_GAS_PRICE_MARGIN as u128 + 100)) + 2;
-        let check_value_wei = increase_gas_price_by_margin(rpc_gas_price_wei);
+        let rpc_gas_price_wei = ((ceiling_gas_price_wei * 100)
+            / (DEFAULT_GAS_PRICE_RETRY_PERCENTAGE as u128 + 100))
+            + 2;
+        let check_value_wei = increase_by_percentage(rpc_gas_price_wei);
 
         test_gas_price_must_not_break_through_ceiling_value_in_the_new_payable_mode(
             test_name,
@@ -340,8 +341,8 @@ mod tests {
         // applied.
         // Adding just 1 didn't work, therefore 2
         let rpc_gas_price_wei =
-            (ceiling_gas_price_wei * 100) / (DEFAULT_GAS_PRICE_MARGIN as u128 + 100) + 2;
-        let check_value_wei = increase_gas_price_by_margin(rpc_gas_price_wei);
+            (ceiling_gas_price_wei * 100) / (DEFAULT_GAS_PRICE_RETRY_PERCENTAGE as u128 + 100) + 2;
+        let check_value_wei = increase_by_percentage(rpc_gas_price_wei);
         let template_1 = RetryTxTemplateBuilder::new()
             .payable_account(&account_1)
             .prev_gas_price_wei(rpc_gas_price_wei - 1)
@@ -384,9 +385,9 @@ mod tests {
         let ceiling_gas_price_wei = chain.rec().gas_price_safe_ceiling_minor;
         // This should be the value that would surplus the ceiling just slightly if the margin is applied
         let border_gas_price_wei =
-            (ceiling_gas_price_wei * 100) / (DEFAULT_GAS_PRICE_MARGIN as u128 + 100) + 2;
+            (ceiling_gas_price_wei * 100) / (DEFAULT_GAS_PRICE_RETRY_PERCENTAGE as u128 + 100) + 2;
         let rpc_gas_price_wei = border_gas_price_wei - 1;
-        let check_value_wei = increase_gas_price_by_margin(border_gas_price_wei);
+        let check_value_wei = increase_by_percentage(border_gas_price_wei);
         let template_1 = RetryTxTemplateBuilder::new()
             .payable_account(&account_1)
             .prev_gas_price_wei(border_gas_price_wei)
@@ -602,8 +603,7 @@ mod tests {
 
         assert_eq!(
             result,
-            (2 * (77_777 + WEB3_MAXIMAL_GAS_LIMIT_MARGIN))
-                * increase_gas_price_by_margin(444_555_666)
+            (2 * (77_777 + WEB3_MAXIMAL_GAS_LIMIT_MARGIN)) * increase_by_percentage(444_555_666)
         );
     }
 
@@ -646,11 +646,11 @@ mod tests {
         let result = subject.estimate_transaction_fee_total(&priced_qualified_payables);
 
         let gas_prices_for_accounts_from_1_to_5 = vec![
-            increase_gas_price_by_margin(rpc_gas_price_wei),
-            increase_gas_price_by_margin(rpc_gas_price_wei),
-            increase_gas_price_by_margin(rpc_gas_price_wei + 1),
-            increase_gas_price_by_margin(rpc_gas_price_wei),
-            increase_gas_price_by_margin(rpc_gas_price_wei + 456_789),
+            increase_by_percentage(rpc_gas_price_wei),
+            increase_by_percentage(rpc_gas_price_wei),
+            increase_by_percentage(rpc_gas_price_wei + 1),
+            increase_by_percentage(rpc_gas_price_wei),
+            increase_by_percentage(rpc_gas_price_wei + 456_789),
         ];
         let expected_result = gas_prices_for_accounts_from_1_to_5
             .into_iter()

--- a/node/src/blockchain/blockchain_agent/agent_web3.rs
+++ b/node/src/blockchain/blockchain_agent/agent_web3.rs
@@ -183,8 +183,8 @@ mod tests {
         ];
         let retry_tx_templates: Vec<RetryTxTemplate> = {
             prev_gas_prices
-                .clone()
-                .into_iter()
+                .iter()
+                .copied()
                 .enumerate()
                 .map(|(idx, prev_gas_price_wei)| {
                     let account = make_payable_account((idx as u64 + 1) * 3_000);
@@ -221,7 +221,6 @@ mod tests {
             if computed_gas_prices.len() != retry_tx_templates.len() {
                 panic!("Corrupted test")
             }
-
             Either::Right(PricedRetryTxTemplates(
                 retry_tx_templates
                     .iter()
@@ -394,8 +393,8 @@ mod tests {
         let ceiling_gas_price_wei = chain.rec().gas_price_safe_ceiling_minor;
         // Once the gas price is computed from latest and prev gas price values, it'll break the ceiling
         let prev_gas_price_wei = ceiling_gas_price_wei + 1 - DEFAULT_GAS_PRICE_RETRY_CONSTANT;
-        let latest_gas_price_wei = prev_gas_price_wei - 100; // Any value lower than prev will work
-        let check_value_wei = increase_by_percentage(prev_gas_price_wei);
+        let latest_gas_price_wei = prev_gas_price_wei - 1;
+        let check_value_wei = prev_gas_price_wei + DEFAULT_GAS_PRICE_RETRY_CONSTANT;
         let template_1 = RetryTxTemplateBuilder::new()
             .payable_account(&account_1)
             .prev_gas_price_wei(prev_gas_price_wei)
@@ -630,8 +629,8 @@ mod tests {
         ];
         let retry_tx_templates: Vec<RetryTxTemplate> = {
             prev_gas_prices
-                .clone()
-                .into_iter()
+                .iter()
+                .copied()
                 .enumerate()
                 .map(|(idx, prev_gas_price_wei)| {
                     let account = make_payable_account((idx as u64 + 1) * 3_000);

--- a/node/src/blockchain/blockchain_agent/agent_web3.rs
+++ b/node/src/blockchain/blockchain_agent/agent_web3.rs
@@ -170,30 +170,32 @@ mod tests {
         let test_name = "returns_correct_priced_qualified_payables_for_retry_payable_scan";
         let consuming_wallet = make_wallet("efg");
         let consuming_wallet_balances = make_zeroed_consuming_wallet_balances();
-        let rpc_gas_price_wei = 444_555_666;
+        let latest_gas_price_wei = 444_555_666;
         let chain = TEST_DEFAULT_CHAIN;
+        let prev_gas_prices = vec![
+            latest_gas_price_wei - 1,
+            latest_gas_price_wei,
+            latest_gas_price_wei + 1,
+            latest_gas_price_wei - 123_456,
+            latest_gas_price_wei + 456_789,
+        ];
         let retry_tx_templates: Vec<RetryTxTemplate> = {
-            vec![
-                rpc_gas_price_wei - 1,
-                rpc_gas_price_wei,
-                rpc_gas_price_wei + 1,
-                rpc_gas_price_wei - 123_456,
-                rpc_gas_price_wei + 456_789,
-            ]
-            .into_iter()
-            .enumerate()
-            .map(|(idx, prev_gas_price_wei)| {
-                let account = make_payable_account((idx as u64 + 1) * 3_000);
-                RetryTxTemplate {
-                    base: BaseTxTemplate::from(&account),
-                    prev_gas_price_wei,
-                    prev_nonce: idx as u64,
-                }
-            })
-            .collect_vec()
+            prev_gas_prices
+                .clone()
+                .into_iter()
+                .enumerate()
+                .map(|(idx, prev_gas_price_wei)| {
+                    let account = make_payable_account((idx as u64 + 1) * 3_000);
+                    RetryTxTemplate {
+                        base: BaseTxTemplate::from(&account),
+                        prev_gas_price_wei,
+                        prev_nonce: idx as u64,
+                    }
+                })
+                .collect_vec()
         };
         let mut subject = BlockchainAgentWeb3::new(
-            rpc_gas_price_wei,
+            latest_gas_price_wei,
             77_777,
             consuming_wallet,
             consuming_wallet_balances,
@@ -205,23 +207,28 @@ mod tests {
             .price_qualified_payables(Either::Right(RetryTxTemplates(retry_tx_templates.clone())));
 
         let expected_result = {
-            let price_wei_for_accounts_from_1_to_5 = vec![
-                increase_by_percentage(rpc_gas_price_wei),
-                increase_by_percentage(rpc_gas_price_wei),
-                increase_by_percentage(rpc_gas_price_wei + 1),
-                increase_by_percentage(rpc_gas_price_wei),
-                increase_by_percentage(rpc_gas_price_wei + 456_789),
-            ];
-            if price_wei_for_accounts_from_1_to_5.len() != retry_tx_templates.len() {
+            let computed_gas_prices = prev_gas_prices
+                .into_iter()
+                .map(|prev_gas_price_wei| {
+                    PricedRetryTxTemplate::compute_gas_price(
+                        latest_gas_price_wei,
+                        prev_gas_price_wei,
+                    )
+                })
+                .collect::<Vec<u128>>();
+            if computed_gas_prices.len() != retry_tx_templates.len() {
                 panic!("Corrupted test")
             }
 
             Either::Right(PricedRetryTxTemplates(
                 retry_tx_templates
                     .iter()
-                    .zip(price_wei_for_accounts_from_1_to_5.into_iter())
-                    .map(|(retry_tx_template, increased_gas_price)| {
-                        PricedRetryTxTemplate::new(retry_tx_template.clone(), increased_gas_price)
+                    .zip(computed_gas_prices.into_iter())
+                    .map(|(retry_tx_template, computed_gas_price_wei)| {
+                        PricedRetryTxTemplate::new(
+                            retry_tx_template.clone(),
+                            computed_gas_price_wei,
+                        )
                     })
                     .collect_vec(),
             ))

--- a/node/src/blockchain/blockchain_agent/agent_web3.rs
+++ b/node/src/blockchain/blockchain_agent/agent_web3.rs
@@ -646,11 +646,14 @@ mod tests {
         let result = subject.estimate_transaction_fee_total(&priced_qualified_payables);
 
         let gas_prices_for_accounts_from_1_to_5 = vec![
-            increase_by_percentage(rpc_gas_price_wei),
-            increase_by_percentage(rpc_gas_price_wei),
-            increase_by_percentage(rpc_gas_price_wei + 1),
-            increase_by_percentage(rpc_gas_price_wei),
-            increase_by_percentage(rpc_gas_price_wei + 456_789),
+            PricedRetryTxTemplate::compute_gas_price(rpc_gas_price_wei, rpc_gas_price_wei - 1),
+            PricedRetryTxTemplate::compute_gas_price(rpc_gas_price_wei, rpc_gas_price_wei),
+            PricedRetryTxTemplate::compute_gas_price(rpc_gas_price_wei, rpc_gas_price_wei + 1),
+            PricedRetryTxTemplate::compute_gas_price(rpc_gas_price_wei, rpc_gas_price_wei),
+            PricedRetryTxTemplate::compute_gas_price(
+                rpc_gas_price_wei,
+                rpc_gas_price_wei + 456_789,
+            ),
         ];
         let expected_result = gas_prices_for_accounts_from_1_to_5
             .into_iter()

--- a/node/src/blockchain/blockchain_bridge.rs
+++ b/node/src/blockchain/blockchain_bridge.rs
@@ -39,7 +39,7 @@ use actix::{Addr, Recipient};
 use futures::Future;
 use itertools::{Either, Itertools};
 use masq_lib::blockchains::chains::Chain;
-use masq_lib::constants::DEFAULT_GAS_PRICE_MARGIN;
+use masq_lib::constants::DEFAULT_GAS_PRICE_RETRY_PERCENTAGE;
 use masq_lib::logger::Logger;
 use masq_lib::ui_gateway::NodeFromUiMessage;
 use regex::Regex;
@@ -542,8 +542,8 @@ struct PendingTxInfo {
     when_sent: SystemTime,
 }
 
-pub fn increase_gas_price_by_margin(gas_price: u128) -> u128 {
-    (gas_price * (100 + DEFAULT_GAS_PRICE_MARGIN as u128)) / 100
+pub fn increase_by_percentage(gas_price: u128) -> u128 {
+    (gas_price * (100 + DEFAULT_GAS_PRICE_RETRY_PERCENTAGE as u128)) / 100
 }
 
 pub struct BlockchainBridgeSubsFactoryReal {}
@@ -775,7 +775,7 @@ mod tests {
         let accountant_received_payment = accountant_recording_arc.lock().unwrap();
         let blockchain_agent_with_context_msg_actual: &PricedTemplatesMessage =
             accountant_received_payment.get_record(0);
-        let computed_gas_price_wei = increase_gas_price_by_margin(0x230000000);
+        let computed_gas_price_wei = increase_by_percentage(0x230000000);
         let expected_tx_templates = tx_templates
             .iter()
             .map(|tx_template| PricedNewTxTemplate {
@@ -2239,7 +2239,7 @@ mod tests {
 
     #[test]
     fn increase_gas_price_by_margin_works() {
-        assert_eq!(increase_gas_price_by_margin(1_000_000_000), 1_300_000_000);
-        assert_eq!(increase_gas_price_by_margin(9_000_000_000), 11_700_000_000);
+        assert_eq!(increase_by_percentage(1_000_000_000), 1_300_000_000);
+        assert_eq!(increase_by_percentage(9_000_000_000), 11_700_000_000);
     }
 }

--- a/node/src/blockchain/blockchain_interface/blockchain_interface_web3/mod.rs
+++ b/node/src/blockchain/blockchain_interface/blockchain_interface_web3/mod.rs
@@ -928,7 +928,7 @@ mod tests {
             PricedRetryTxTemplate::new(retry_2, increase_by_percentage(latest_gas_price_wei)),
             PricedRetryTxTemplate::new(
                 retry_3,
-                latest_gas_price_wei + 1 + DEFAULT_GAS_PRICE_RETRY_CONSTANT,
+                (latest_gas_price_wei + 1) + DEFAULT_GAS_PRICE_RETRY_CONSTANT,
             ),
         ]);
 

--- a/node/src/blockchain/blockchain_interface/blockchain_interface_web3/mod.rs
+++ b/node/src/blockchain/blockchain_interface/blockchain_interface_web3/mod.rs
@@ -473,7 +473,6 @@ mod tests {
     use super::*;
     use crate::accountant::scanners::pending_payable_scanner::utils::TxHashByTable;
     use crate::accountant::test_utils::make_payable_account;
-    use crate::blockchain::blockchain_bridge::increase_gas_price_by_margin;
     use crate::blockchain::blockchain_interface::blockchain_interface_web3::{
         BlockchainInterfaceWeb3, CONTRACT_ABI, REQUESTS_IN_PARALLEL, TRANSACTION_LITERAL,
         TRANSFER_METHOD_ID,
@@ -509,6 +508,7 @@ mod tests {
     use crate::accountant::scanners::payable_scanner::tx_templates::initial::retry::RetryTxTemplates;
     use crate::accountant::scanners::payable_scanner::tx_templates::priced::retry::PricedRetryTxTemplate;
     use crate::accountant::scanners::payable_scanner::tx_templates::test_utils::RetryTxTemplateBuilder;
+    use crate::blockchain::blockchain_bridge::increase_by_percentage;
 
     #[test]
     fn constants_are_correct() {
@@ -888,7 +888,7 @@ mod tests {
         let gas_price_wei_from_rpc_u128_wei =
             u128::from_str_radix(&gas_price_wei_from_rpc_hex[2..], 16).unwrap();
         let gas_price_wei_from_rpc_u128_wei_with_margin =
-            increase_gas_price_by_margin(gas_price_wei_from_rpc_u128_wei);
+            increase_by_percentage(gas_price_wei_from_rpc_u128_wei);
         let expected_result = Either::Left(PricedNewTxTemplates::new(
             tx_templates.clone(),
             gas_price_wei_from_rpc_u128_wei_with_margin,
@@ -923,12 +923,9 @@ mod tests {
         let retry_tx_templates =
             RetryTxTemplates(vec![retry_1.clone(), retry_2.clone(), retry_3.clone()]);
         let expected_retry_tx_templates = PricedRetryTxTemplates(vec![
-            PricedRetryTxTemplate::new(retry_1, increase_gas_price_by_margin(gas_price_from_rpc)),
-            PricedRetryTxTemplate::new(retry_2, increase_gas_price_by_margin(gas_price_from_rpc)),
-            PricedRetryTxTemplate::new(
-                retry_3,
-                increase_gas_price_by_margin(gas_price_from_rpc + 1),
-            ),
+            PricedRetryTxTemplate::new(retry_1, increase_by_percentage(gas_price_from_rpc)),
+            PricedRetryTxTemplate::new(retry_2, increase_by_percentage(gas_price_from_rpc)),
+            PricedRetryTxTemplate::new(retry_3, increase_by_percentage(gas_price_from_rpc + 1)),
         ]);
 
         let expected_estimated_transaction_fee_total = 285_979_200_073_328;

--- a/node/src/blockchain/blockchain_interface/blockchain_interface_web3/mod.rs
+++ b/node/src/blockchain/blockchain_interface/blockchain_interface_web3/mod.rs
@@ -504,6 +504,7 @@ mod tests {
     use itertools::Either;
     use web3::transports::Http;
     use web3::types::{H256, U256};
+    use masq_lib::constants::DEFAULT_GAS_PRICE_RETRY_CONSTANT;
     use crate::accountant::scanners::payable_scanner::tx_templates::initial::new::NewTxTemplates;
     use crate::accountant::scanners::payable_scanner::tx_templates::initial::retry::RetryTxTemplates;
     use crate::accountant::scanners::payable_scanner::tx_templates::priced::retry::PricedRetryTxTemplate;
@@ -906,29 +907,32 @@ mod tests {
     #[test]
     fn blockchain_interface_web3_can_introduce_blockchain_agent_in_the_retry_payables_mode() {
         let gas_price_wei = "0x3B9ACA00"; // 1000000000
-        let gas_price_from_rpc = u128::from_str_radix(&gas_price_wei[2..], 16).unwrap();
+        let latest_gas_price_wei = u128::from_str_radix(&gas_price_wei[2..], 16).unwrap();
         let retry_1 = RetryTxTemplateBuilder::default()
             .payable_account(&make_payable_account(12))
-            .prev_gas_price_wei(gas_price_from_rpc - 1)
+            .prev_gas_price_wei(latest_gas_price_wei - 1)
             .build();
         let retry_2 = RetryTxTemplateBuilder::default()
             .payable_account(&make_payable_account(34))
-            .prev_gas_price_wei(gas_price_from_rpc)
+            .prev_gas_price_wei(latest_gas_price_wei)
             .build();
         let retry_3 = RetryTxTemplateBuilder::default()
             .payable_account(&make_payable_account(56))
-            .prev_gas_price_wei(gas_price_from_rpc + 1)
+            .prev_gas_price_wei(latest_gas_price_wei + 1)
             .build();
 
         let retry_tx_templates =
             RetryTxTemplates(vec![retry_1.clone(), retry_2.clone(), retry_3.clone()]);
         let expected_retry_tx_templates = PricedRetryTxTemplates(vec![
-            PricedRetryTxTemplate::new(retry_1, increase_by_percentage(gas_price_from_rpc)),
-            PricedRetryTxTemplate::new(retry_2, increase_by_percentage(gas_price_from_rpc)),
-            PricedRetryTxTemplate::new(retry_3, increase_by_percentage(gas_price_from_rpc + 1)),
+            PricedRetryTxTemplate::new(retry_1, increase_by_percentage(latest_gas_price_wei)),
+            PricedRetryTxTemplate::new(retry_2, increase_by_percentage(latest_gas_price_wei)),
+            PricedRetryTxTemplate::new(
+                retry_3,
+                latest_gas_price_wei + 1 + DEFAULT_GAS_PRICE_RETRY_CONSTANT,
+            ),
         ]);
 
-        let expected_estimated_transaction_fee_total = 285_979_200_073_328;
+        let expected_estimated_transaction_fee_total = 263_981_166_713_328;
 
         test_blockchain_interface_web3_can_introduce_blockchain_agent(
             Either::Right(retry_tx_templates),

--- a/node/src/blockchain/blockchain_interface_initializer.rs
+++ b/node/src/blockchain/blockchain_interface_initializer.rs
@@ -47,7 +47,7 @@ mod tests {
     use crate::accountant::scanners::payable_scanner::tx_templates::initial::new::NewTxTemplates;
     use crate::accountant::scanners::payable_scanner::tx_templates::priced::new::PricedNewTxTemplates;
     use crate::accountant::test_utils::make_payable_account;
-    use crate::blockchain::blockchain_bridge::increase_gas_price_by_margin;
+    use crate::blockchain::blockchain_bridge::increase_by_percentage;
     use crate::blockchain::blockchain_interface_initializer::BlockchainInterfaceInitializer;
     use crate::test_utils::make_wallet;
     use futures::Future;
@@ -88,7 +88,7 @@ mod tests {
             .unwrap();
         assert_eq!(blockchain_agent.consuming_wallet(), &payable_wallet);
         let result = blockchain_agent.price_qualified_payables(Either::Left(tx_templates.clone()));
-        let gas_price_with_margin = increase_gas_price_by_margin(1_000_000_000);
+        let gas_price_with_margin = increase_by_percentage(1_000_000_000);
         let expected_result = Either::Left(PricedNewTxTemplates::new(
             tx_templates,
             gas_price_with_margin,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces margin-based gas logic with percentage-based increases and a constant bump for retries, updating constants, computation, and tests across pricing and blockchain layers.
> 
> - **Gas pricing logic**:
>   - Replace `DEFAULT_GAS_PRICE_MARGIN` with `DEFAULT_GAS_PRICE_RETRY_PERCENTAGE` and add `DEFAULT_GAS_PRICE_RETRY_CONSTANT` in `masq_lib/src/constants.rs`.
>   - Rename `increase_gas_price_by_margin` to `increase_by_percentage` in `node/src/blockchain/blockchain_bridge.rs` and update all callers (`priced/new.rs`, `agent_web3.rs`, `blockchain_interface_web3/mod.rs`, `blockchain_interface_initializer.rs`).
>   - Retry computation change in `priced/retry.rs`:
>     - If `latest_gas_price_wei >= prev_gas_price_wei` -> use `increase_by_percentage(latest)`.
>     - Else -> use `prev + DEFAULT_GAS_PRICE_RETRY_CONSTANT`.
>   - Enforce gas price ceiling using the new calculations and adjust related log messages.
> - **Tests**:
>   - Update expected values to use `increase_by_percentage` and new retry rules across `agent_web3.rs`, `blockchain_bridge.rs`, `blockchain_interface_web3/mod.rs`, and initializer tests.
>   - Add unit tests for `compute_gas_price` behavior in `priced/retry.rs`.
>   - Adjust fee estimations and expected logs to reflect new pricing formula.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82cc8b7d73f933a83dc54abc6c2deba801224b55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->