### PR TITLE
GH-598: receivables scheduling hot fix — review two

### DIFF
--- a/masq_lib/src/constants.rs
+++ b/masq_lib/src/constants.rs
@@ -83,7 +83,8 @@ pub const VALUE_EXCEEDS_ALLOWED_LIMIT: u64 = ACCOUNTANT_PREFIX | 3;
 pub const MASQ_TOTAL_SUPPLY: u64 = 37_500_000;
 
 pub const DEFAULT_GAS_PRICE: u64 = 1; //TODO ?? Really
-pub const DEFAULT_GAS_PRICE_MARGIN: u64 = 30;
+pub const DEFAULT_GAS_PRICE_RETRY_PERCENTAGE: u64 = 30;
+pub const DEFAULT_GAS_PRICE_RETRY_CONSTANT: u128 = 5_000;
 pub const DEFAULT_MAX_BLOCK_COUNT: u64 = 100_000;
 
 //chains
@@ -142,7 +143,8 @@ mod tests {
         assert_eq!(CURRENT_LOGFILE_NAME, "MASQNode_rCURRENT.log");
         assert_eq!(MASQ_PROMPT, "masq> ");
         assert_eq!(DEFAULT_GAS_PRICE, 1);
-        assert_eq!(DEFAULT_GAS_PRICE_MARGIN, 30);
+        assert_eq!(DEFAULT_GAS_PRICE_RETRY_PERCENTAGE, 30);
+        assert_eq!(DEFAULT_GAS_PRICE_RETRY_CONSTANT, 5_000);
         assert_eq!(WALLET_ADDRESS_LENGTH, 42);
         assert_eq!(MASQ_TOTAL_SUPPLY, 37_500_000);
         assert_eq!(WEIS_IN_GWEI, 1_000_000_000);

--- a/node/src/accountant/mod.rs
+++ b/node/src/accountant/mod.rs
@@ -30,7 +30,7 @@ use crate::accountant::scanners::pending_payable_scanner::utils::{
     PendingPayableScanResult, TxHashByTable,
 };
 use crate::accountant::scanners::scan_schedulers::{
-    ScanReschedulingAfterEarlyStop, ScanSchedulers, StartScanFallibleScanner,
+    ScanReschedulingAfterEarlyStop, ScanSchedulers, UnableToStartScanner,
 };
 use crate::accountant::scanners::{Scanners, StartScanError};
 use crate::blockchain::blockchain_bridge::{
@@ -416,15 +416,19 @@ impl Handler<ReceivedPayments> for Accountant {
     type Result = ();
 
     fn handle(&mut self, msg: ReceivedPayments, ctx: &mut Self::Context) -> Self::Result {
-        if let Some(node_to_ui_msg) = self.scanners.finish_receivable_scan(msg, &self.logger) {
-            self.ui_message_sub_opt
-                .as_ref()
-                .expect("UIGateway is not bound")
-                .try_send(node_to_ui_msg)
-                .expect("UIGateway is dead");
+        match self.scanners.finish_receivable_scan(msg, &self.logger) {
+            None => self.scan_schedulers.receivable.schedule(ctx, &self.logger),
+            Some(node_to_ui_msg) => {
+                self.ui_message_sub_opt
+                    .as_ref()
+                    .expect("UIGateway is not bound")
+                    .try_send(node_to_ui_msg)
+                    .expect("UIGateway is dead");
+                // Externally triggered scans are not allowed to provoke an unwinding scan sequence
+                // with intervals. The only exception is the PendingPayableScanner that is always
+                // followed by the retry-payable scanner in a tight tandem.
+            }
         }
-
-        self.scan_schedulers.receivable.schedule(ctx, &self.logger);
     }
 }
 
@@ -1009,8 +1013,8 @@ impl Accountant {
                     .expect("BlockchainBridge is dead");
                 ScanReschedulingAfterEarlyStop::DoNotSchedule
             }
-            Err(e) => self.handle_start_scan_error_and_prevent_scan_stall_point(
-                StartScanFallibleScanner::NewPayables,
+            Err(e) => self.handle_start_scan_error(
+                UnableToStartScanner::NewPayables,
                 e,
                 response_skeleton_opt,
             ),
@@ -1042,8 +1046,8 @@ impl Accountant {
             }
             Err(e) => {
                 // Any error here panics by design, so the return value is unreachable/ignored.
-                let _ = self.handle_start_scan_error_and_prevent_scan_stall_point(
-                    StartScanFallibleScanner::RetryPayables,
+                let _ = self.handle_start_scan_error(
+                    UnableToStartScanner::RetryPayables,
                     e,
                     response_skeleton_opt,
                 );
@@ -1078,8 +1082,8 @@ impl Accountant {
             }
             Err(e) => {
                 let initial_pending_payable_scan = self.scanners.initial_pending_payable_scan();
-                self.handle_start_scan_error_and_prevent_scan_stall_point(
-                    StartScanFallibleScanner::PendingPayables {
+                self.handle_start_scan_error(
+                    UnableToStartScanner::PendingPayables {
                         initial_pending_payable_scan,
                     },
                     e,
@@ -1095,9 +1099,9 @@ impl Accountant {
         hint
     }
 
-    fn handle_start_scan_error_and_prevent_scan_stall_point(
+    fn handle_start_scan_error(
         &self,
-        scanner: StartScanFallibleScanner,
+        scanner: UnableToStartScanner,
         e: StartScanError,
         response_skeleton_opt: Option<ResponseSkeleton>,
     ) -> ScanReschedulingAfterEarlyStop {
@@ -1146,8 +1150,8 @@ impl Accountant {
             Err(e) =>
             // Any error here panics by design, so the return value is unreachable/ignored.
             {
-                self.handle_start_scan_error_and_prevent_scan_stall_point(
-                    StartScanFallibleScanner::Receivables,
+                self.handle_start_scan_error(
+                    UnableToStartScanner::Receivables,
                     e,
                     response_skeleton_opt,
                 )
@@ -2297,7 +2301,7 @@ mod tests {
         let (peer_actors, peer_addresses) = peer_actors_builder()
             .blockchain_bridge(blockchain_bridge)
             .ui_gateway(ui_gateway)
-            .build_providing_addresses();
+            .build_with_addresses();
         let subject_addr = subject.start();
         let system = System::new("test");
         let response_skeleton_opt = Some(ResponseSkeleton {
@@ -2774,7 +2778,7 @@ mod tests {
             receivable_scan_interval: Duration::from_millis(10_000),
         });
         config.automatic_scans_enabled = false;
-        let subject = AccountantBuilder::default()
+        let mut subject = AccountantBuilder::default()
             .bootstrapper_config(config)
             .config_dao(
                 ConfigDaoMock::new()
@@ -2782,6 +2786,9 @@ mod tests {
                     .set_result(Ok(())),
             )
             .build();
+        // Another scan must not be scheduled
+        subject.scan_schedulers.receivable.handle =
+            Box::new(NotifyLaterHandleMock::default().panic_on_schedule_attempt());
         let (ui_gateway, _, ui_gateway_recording_arc) = make_recorder();
         let subject_addr = subject.start();
         let system = System::new("test");
@@ -3023,7 +3030,7 @@ mod tests {
                 pending_payable_scanner,
                 receivable_scanner,
             );
-        let (peer_actors, addresses) = peer_actors_builder().build_providing_addresses();
+        let (peer_actors, addresses) = peer_actors_builder().build_with_addresses();
         let subject_addr: Addr<Accountant> = subject.start();
         let subject_subs = Accountant::make_subs_from(&subject_addr);
         let expected_tx_receipts_msg = TxReceiptsMessage {
@@ -3683,7 +3690,7 @@ mod tests {
         let subject_subs = Accountant::make_subs_from(&subject_addr);
         let (peer_actors, peer_actors_addrs) = peer_actors_builder()
             .blockchain_bridge(blockchain_bridge)
-            .build_providing_addresses();
+            .build_with_addresses();
         send_bind_message!(subject_subs, peer_actors);
         let counter_msg = ReceivedPayments {
             timestamp: SystemTime::now(),

--- a/node/src/accountant/scanners/mod.rs
+++ b/node/src/accountant/scanners/mod.rs
@@ -122,7 +122,10 @@ impl Scanners {
             });
         }
 
-        Self::start_correct_payable_scanner::<ScanForNewPayables>(
+        <(dyn MultistageDualPayableScanner) as StartableScanner<
+            ScanForNewPayables,
+            InitialTemplatesMessage,
+        >>::start_scan(
             &mut *self.payable,
             wallet,
             timestamp,
@@ -150,7 +153,10 @@ impl Scanners {
             )
         }
 
-        Self::start_correct_payable_scanner::<ScanForRetryPayables>(
+        <(dyn MultistageDualPayableScanner) as StartableScanner<
+            ScanForRetryPayables,
+            InitialTemplatesMessage,
+        >>::start_scan(
             &mut *self.payable,
             wallet,
             timestamp,
@@ -297,28 +303,6 @@ impl Scanners {
 
     pub fn unset_initial_pending_payable_scan(&mut self) {
         self.initial_pending_payable_scan = false
-    }
-
-    // This is a helper function reducing a boilerplate of complex trait resolving where
-    // the compiler requires to specify which trigger message distinguishes the scan to run.
-    // The payable scanner offers two modes through doubled implementations of StartableScanner
-    // which uses the trigger message type as the only distinction between them.
-    fn start_correct_payable_scanner<'a, TriggerMessage>(
-        scanner: &'a mut (dyn MultistageDualPayableScanner + 'a),
-        wallet: &Wallet,
-        timestamp: SystemTime,
-        response_skeleton_opt: Option<ResponseSkeleton>,
-        logger: &Logger,
-    ) -> Result<InitialTemplatesMessage, StartScanError>
-    where
-        TriggerMessage: Message,
-        (dyn MultistageDualPayableScanner + 'a):
-            StartableScanner<TriggerMessage, InitialTemplatesMessage>,
-    {
-        <(dyn MultistageDualPayableScanner + 'a) as StartableScanner<
-            TriggerMessage,
-            InitialTemplatesMessage,
-        >>::start_scan(scanner, wallet, timestamp, response_skeleton_opt, logger)
     }
 
     fn check_general_conditions_for_pending_payable_scan(

--- a/node/src/accountant/scanners/mod.rs
+++ b/node/src/accountant/scanners/mod.rs
@@ -174,10 +174,14 @@ impl Scanners {
         automatic_scans_enabled: bool,
     ) -> Result<RequestTransactionReceipts, StartScanError> {
         let triggered_manually = response_skeleton_opt.is_some();
-        self.check_general_conditions_for_pending_payable_scan(
-            triggered_manually,
-            automatic_scans_enabled,
-        )?;
+        if triggered_manually && automatic_scans_enabled {
+            return Err(StartScanError::ManualTriggerError(
+                ManulTriggerError::AutomaticScanConflict,
+            ));
+        }
+
+        self.check_pending_payable_existence(triggered_manually)?;
+
         match (
             self.pending_payable.scan_started_at(),
             self.payable.scan_started_at(),
@@ -305,19 +309,14 @@ impl Scanners {
         self.initial_pending_payable_scan = false
     }
 
-    fn check_general_conditions_for_pending_payable_scan(
+    fn check_pending_payable_existence(
         &mut self,
         triggered_manually: bool,
-        automatic_scans_enabled: bool,
     ) -> Result<(), StartScanError> {
-        if triggered_manually && automatic_scans_enabled {
-            return Err(StartScanError::ManualTriggerError(
-                ManulTriggerError::AutomaticScanConflict,
-            ));
-        }
         if self.initial_pending_payable_scan {
             return Ok(());
         }
+
         if triggered_manually && !self.aware_of_unresolved_pending_payable {
             return Err(StartScanError::ManualTriggerError(
                 ManulTriggerError::UnnecessaryRequest {
@@ -1327,8 +1326,8 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "internal error: entered unreachable code: Automatic pending payable \
-    scan should never start if there are no pending payables to process."
+        expected = "internal error: entered unreachable code: Automatic pending payable scan should \
+        never start if there are no pending payables to process."
     )]
     fn pending_payable_scanner_bumps_into_zero_pending_payable_awareness_in_the_automatic_mode() {
         let consuming_wallet = make_paying_wallet(b"consuming");
@@ -1347,11 +1346,12 @@ mod tests {
     }
 
     #[test]
-    fn check_general_conditions_for_pending_payable_scan_if_it_is_initial_pending_payable_scan() {
+    fn check_pending_payable_existence_for_initial_pending_payable_scan_and_zero_awareness() {
         let mut subject = make_dull_subject();
+        subject.aware_of_unresolved_pending_payable = false;
         subject.initial_pending_payable_scan = true;
 
-        let result = subject.check_general_conditions_for_pending_payable_scan(false, true);
+        let result = subject.check_pending_payable_existence(false);
 
         assert_eq!(result, Ok(()));
         assert_eq!(subject.initial_pending_payable_scan, true);

--- a/node/src/accountant/scanners/payable_scanner/start_scan.rs
+++ b/node/src/accountant/scanners/payable_scanner/start_scan.rs
@@ -89,7 +89,7 @@ mod tests {
     use crate::accountant::scanners::payable_scanner::tx_templates::initial::retry::{
         RetryTxTemplate, RetryTxTemplates,
     };
-    use crate::accountant::scanners::Scanners;
+    use crate::accountant::scanners::payable_scanner::MultistageDualPayableScanner;
     use crate::accountant::test_utils::{
         make_payable_account, FailedPayableDaoMock, PayableDaoMock,
     };
@@ -144,7 +144,10 @@ mod tests {
             .payable_dao(payable_dao)
             .build();
 
-        let result = Scanners::start_correct_payable_scanner::<ScanForRetryPayables>(
+        let result = <(dyn MultistageDualPayableScanner) as StartableScanner<
+            ScanForRetryPayables,
+            InitialTemplatesMessage,
+        >>::start_scan(
             &mut subject,
             &consuming_wallet,
             timestamp,

--- a/node/src/accountant/scanners/payable_scanner/tx_templates/priced/new.rs
+++ b/node/src/accountant/scanners/payable_scanner/tx_templates/priced/new.rs
@@ -4,7 +4,7 @@ use crate::accountant::scanners::payable_scanner::tx_templates::initial::new::{
     NewTxTemplate, NewTxTemplates,
 };
 use crate::accountant::scanners::payable_scanner::tx_templates::BaseTxTemplate;
-use crate::blockchain::blockchain_bridge::increase_gas_price_by_margin;
+use crate::blockchain::blockchain_bridge::increase_by_percentage;
 use masq_lib::logger::Logger;
 use std::ops::Deref;
 use thousands::Separable;
@@ -63,7 +63,7 @@ impl PricedNewTxTemplates {
         ceil: u128,
         logger: &Logger,
     ) -> Self {
-        let computed_gas_price_wei = increase_gas_price_by_margin(latest_gas_price_wei);
+        let computed_gas_price_wei = increase_by_percentage(latest_gas_price_wei);
 
         let safe_gas_price_wei = if computed_gas_price_wei > ceil {
             warning!(

--- a/node/src/accountant/scanners/payable_scanner/tx_templates/priced/retry.rs
+++ b/node/src/accountant/scanners/payable_scanner/tx_templates/priced/retry.rs
@@ -4,7 +4,8 @@ use crate::accountant::scanners::payable_scanner::tx_templates::initial::retry::
     RetryTxTemplate, RetryTxTemplates,
 };
 use crate::accountant::scanners::payable_scanner::tx_templates::BaseTxTemplate;
-use crate::blockchain::blockchain_bridge::increase_gas_price_by_margin;
+use crate::blockchain::blockchain_bridge::increase_by_percentage;
+use masq_lib::constants::DEFAULT_GAS_PRICE_RETRY_CONSTANT;
 use masq_lib::logger::Logger;
 use std::ops::{Deref, DerefMut};
 use thousands::Separable;
@@ -34,7 +35,7 @@ impl PricedRetryTxTemplate {
     ) -> PricedRetryTxTemplate {
         let receiver = retry_tx_template.base.receiver_address;
         let computed_gas_price_wei =
-            Self::compute_gas_price(retry_tx_template.prev_gas_price_wei, latest_gas_price_wei);
+            Self::compute_gas_price(latest_gas_price_wei, retry_tx_template.prev_gas_price_wei);
 
         let safe_gas_price_wei = if computed_gas_price_wei > ceil {
             log_builder.push(receiver, computed_gas_price_wei);
@@ -46,10 +47,12 @@ impl PricedRetryTxTemplate {
         PricedRetryTxTemplate::new(retry_tx_template, safe_gas_price_wei)
     }
 
-    fn compute_gas_price(latest_gas_price_wei: u128, prev_gas_price_wei: u128) -> u128 {
-        let gas_price_wei = latest_gas_price_wei.max(prev_gas_price_wei);
-
-        increase_gas_price_by_margin(gas_price_wei)
+    pub fn compute_gas_price(latest_gas_price_wei: u128, prev_gas_price_wei: u128) -> u128 {
+        if latest_gas_price_wei >= prev_gas_price_wei {
+            increase_by_percentage(latest_gas_price_wei)
+        } else {
+            prev_gas_price_wei + DEFAULT_GAS_PRICE_RETRY_CONSTANT
+        }
     }
 }
 
@@ -165,5 +168,46 @@ impl RetryLogBuilder {
                 )
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_gas_price_increases_by_percentage_if_latest_is_higher() {
+        let latest_gas_price_wei = 101;
+        let prev_gas_price_wei = 100;
+
+        let computed_gas_price =
+            PricedRetryTxTemplate::compute_gas_price(latest_gas_price_wei, prev_gas_price_wei);
+
+        let expected_gas_price = increase_by_percentage(latest_gas_price_wei);
+        assert_eq!(computed_gas_price, expected_gas_price);
+    }
+
+    #[test]
+    fn compute_gas_price_increases_by_percentage_if_latest_is_equal() {
+        let latest_gas_price_wei = 100;
+        let prev_gas_price_wei = 100;
+
+        let computed_gas_price =
+            PricedRetryTxTemplate::compute_gas_price(latest_gas_price_wei, prev_gas_price_wei);
+
+        let expected_gas_price = increase_by_percentage(latest_gas_price_wei);
+        assert_eq!(computed_gas_price, expected_gas_price);
+    }
+
+    #[test]
+    fn compute_gas_price_increments_previous_by_constant_if_latest_is_lower() {
+        let latest_gas_price_wei = 99;
+        let prev_gas_price_wei = 100;
+
+        let computed_gas_price =
+            PricedRetryTxTemplate::compute_gas_price(latest_gas_price_wei, prev_gas_price_wei);
+
+        let expected_gas_price = prev_gas_price_wei + DEFAULT_GAS_PRICE_RETRY_CONSTANT;
+        assert_eq!(computed_gas_price, expected_gas_price);
     }
 }

--- a/node/src/accountant/scanners/scan_schedulers.rs
+++ b/node/src/accountant/scanners/scan_schedulers.rs
@@ -51,31 +51,31 @@ pub enum ScanReschedulingAfterEarlyStop {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum StartScanFallibleScanner {
+pub enum UnableToStartScanner {
     NewPayables,
     RetryPayables,
     PendingPayables { initial_pending_payable_scan: bool },
     Receivables,
 }
 
-impl Display for StartScanFallibleScanner {
+impl Display for UnableToStartScanner {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            StartScanFallibleScanner::NewPayables => write!(f, "NewPayables"),
-            StartScanFallibleScanner::RetryPayables => write!(f, "RetryPayables"),
-            StartScanFallibleScanner::PendingPayables { .. } => write!(f, "PendingPayables"),
-            StartScanFallibleScanner::Receivables => write!(f, "Receivables"),
+            UnableToStartScanner::NewPayables => write!(f, "NewPayables"),
+            UnableToStartScanner::RetryPayables => write!(f, "RetryPayables"),
+            UnableToStartScanner::PendingPayables { .. } => write!(f, "PendingPayables"),
+            UnableToStartScanner::Receivables => write!(f, "Receivables"),
         }
     }
 }
 
-impl From<StartScanFallibleScanner> for ScanType {
-    fn from(scanner: StartScanFallibleScanner) -> Self {
+impl From<UnableToStartScanner> for ScanType {
+    fn from(scanner: UnableToStartScanner) -> Self {
         match scanner {
-            StartScanFallibleScanner::NewPayables => ScanType::Payables,
-            StartScanFallibleScanner::RetryPayables => ScanType::Payables,
-            StartScanFallibleScanner::PendingPayables { .. } => ScanType::PendingPayables,
-            StartScanFallibleScanner::Receivables => ScanType::Receivables,
+            UnableToStartScanner::NewPayables => ScanType::Payables,
+            UnableToStartScanner::RetryPayables => ScanType::Payables,
+            UnableToStartScanner::PendingPayables { .. } => ScanType::PendingPayables,
+            UnableToStartScanner::Receivables => ScanType::Receivables,
         }
     }
 }
@@ -253,7 +253,7 @@ where
 pub trait RescheduleScanOnErrorResolver {
     fn resolve_rescheduling_on_error(
         &self,
-        scanner: StartScanFallibleScanner,
+        scanner: UnableToStartScanner,
         error: &StartScanError,
         is_externally_triggered: bool,
         logger: &Logger,
@@ -266,26 +266,26 @@ pub struct RescheduleScanOnErrorResolverReal {}
 impl RescheduleScanOnErrorResolver for RescheduleScanOnErrorResolverReal {
     fn resolve_rescheduling_on_error(
         &self,
-        scanner: StartScanFallibleScanner,
+        scanner: UnableToStartScanner,
         error: &StartScanError,
         is_externally_triggered: bool,
         logger: &Logger,
     ) -> ScanReschedulingAfterEarlyStop {
         let reschedule_hint = match scanner {
-            StartScanFallibleScanner::NewPayables => {
+            UnableToStartScanner::NewPayables => {
                 Self::resolve_new_payables(error, is_externally_triggered)
             }
-            StartScanFallibleScanner::RetryPayables => {
+            UnableToStartScanner::RetryPayables => {
                 Self::resolve_retry_payables(error, is_externally_triggered)
             }
-            StartScanFallibleScanner::PendingPayables {
+            UnableToStartScanner::PendingPayables {
                 initial_pending_payable_scan,
             } => Self::resolve_pending_payables(
                 error,
                 initial_pending_payable_scan,
                 is_externally_triggered,
             ),
-            StartScanFallibleScanner::Receivables => {
+            UnableToStartScanner::Receivables => {
                 Self::resolve_receivables(error, is_externally_triggered)
             }
         };
@@ -395,7 +395,7 @@ impl RescheduleScanOnErrorResolverReal {
     }
 
     fn log_rescheduling(
-        scanner: StartScanFallibleScanner,
+        scanner: UnableToStartScanner,
         is_externally_triggered: bool,
         logger: &Logger,
         reschedule_hint: &ScanReschedulingAfterEarlyStop,
@@ -420,7 +420,7 @@ impl RescheduleScanOnErrorResolverReal {
 mod tests {
     use crate::accountant::scanners::scan_schedulers::{
         NewPayableScanIntervalComputer, NewPayableScanIntervalComputerReal,
-        ScanReschedulingAfterEarlyStop, ScanSchedulers, ScanTiming, StartScanFallibleScanner,
+        ScanReschedulingAfterEarlyStop, ScanSchedulers, ScanTiming, UnableToStartScanner,
     };
     use crate::accountant::scanners::test_utils::NewPayableScanIntervalComputerMock;
     use crate::accountant::scanners::{ManulTriggerError, StartScanError};
@@ -738,14 +738,14 @@ mod tests {
         test_what_if_externally_triggered(
             &format!("{}(initial_pending_payable_scan = false)", test_name),
             &subject,
-            StartScanFallibleScanner::PendingPayables {
+            UnableToStartScanner::PendingPayables {
                 initial_pending_payable_scan: false,
             },
         );
         test_what_if_externally_triggered(
             &format!("{}(initial_pending_payable_scan = true)", test_name),
             &subject,
-            StartScanFallibleScanner::PendingPayables {
+            UnableToStartScanner::PendingPayables {
                 initial_pending_payable_scan: true,
             },
         );
@@ -754,7 +754,7 @@ mod tests {
     fn test_what_if_externally_triggered(
         test_name: &str,
         subject: &ScanSchedulers,
-        scanner: StartScanFallibleScanner,
+        scanner: UnableToStartScanner,
     ) {
         init_test_logging();
         let logger = Logger::new(test_name);
@@ -793,7 +793,7 @@ mod tests {
         let result = subject
             .reschedule_on_error_resolver
             .resolve_rescheduling_on_error(
-                StartScanFallibleScanner::PendingPayables {
+                UnableToStartScanner::PendingPayables {
                     initial_pending_payable_scan: true,
                 },
                 &StartScanError::NothingToProcess,
@@ -826,7 +826,7 @@ mod tests {
         let _ = subject
             .reschedule_on_error_resolver
             .resolve_rescheduling_on_error(
-                StartScanFallibleScanner::PendingPayables {
+                UnableToStartScanner::PendingPayables {
                     initial_pending_payable_scan: false,
                 },
                 &StartScanError::NothingToProcess,
@@ -842,7 +842,7 @@ mod tests {
             "resolve_error_if_no_consuming_wallet_found_in_initial_pending_payable_scan";
         let logger = Logger::new(test_name);
         let subject = ScanSchedulers::new(*TEST_SCAN_INTERVALS, true);
-        let scanner = StartScanFallibleScanner::PendingPayables {
+        let scanner = UnableToStartScanner::PendingPayables {
             initial_pending_payable_scan: true,
         };
 
@@ -877,7 +877,7 @@ mod tests {
     fn pending_payable_scan_attempt_if_no_consuming_wallet_found_mustnt_happen_if_not_initial_scan()
     {
         let subject = ScanSchedulers::new(*TEST_SCAN_INTERVALS, true);
-        let scanner = StartScanFallibleScanner::PendingPayables {
+        let scanner = UnableToStartScanner::PendingPayables {
             initial_pending_payable_scan: false,
         };
 
@@ -894,12 +894,12 @@ mod tests {
     #[test]
     fn resolve_error_for_pending_payables_if_null_scanner_is_used_in_automatic_mode() {
         test_resolve_error_if_null_scanner_is_used_in_automatic_mode(
-            StartScanFallibleScanner::PendingPayables {
+            UnableToStartScanner::PendingPayables {
                 initial_pending_payable_scan: true,
             },
         );
         test_resolve_error_if_null_scanner_is_used_in_automatic_mode(
-            StartScanFallibleScanner::PendingPayables {
+            UnableToStartScanner::PendingPayables {
                 initial_pending_payable_scan: false,
             },
         );
@@ -917,7 +917,7 @@ mod tests {
                     subject
                         .reschedule_on_error_resolver
                         .resolve_rescheduling_on_error(
-                            StartScanFallibleScanner::PendingPayables {
+                            UnableToStartScanner::PendingPayables {
                                 initial_pending_payable_scan,
                             },
                             *error,
@@ -961,7 +961,7 @@ mod tests {
         test_what_if_externally_triggered(
             test_name,
             &subject,
-            StartScanFallibleScanner::RetryPayables {},
+            UnableToStartScanner::RetryPayables {},
         );
     }
 
@@ -974,7 +974,7 @@ mod tests {
                 subject
                     .reschedule_on_error_resolver
                     .resolve_rescheduling_on_error(
-                        StartScanFallibleScanner::RetryPayables,
+                        UnableToStartScanner::RetryPayables,
                         error,
                         false,
                         &Logger::new("test"),
@@ -1004,7 +1004,7 @@ mod tests {
         test_what_if_externally_triggered(
             test_name,
             &subject,
-            StartScanFallibleScanner::NewPayables {},
+            UnableToStartScanner::NewPayables {},
         );
     }
 
@@ -1019,7 +1019,7 @@ mod tests {
         let _ = subject
             .reschedule_on_error_resolver
             .resolve_rescheduling_on_error(
-                StartScanFallibleScanner::NewPayables,
+                UnableToStartScanner::NewPayables,
                 &StartScanError::ScanAlreadyRunning {
                     cross_scan_cause_opt: None,
                     started_at: SystemTime::now(),
@@ -1032,7 +1032,7 @@ mod tests {
     #[test]
     fn resolve_error_for_new_payables_if_null_scanner_is_used_in_automatic_mode() {
         test_resolve_error_if_null_scanner_is_used_in_automatic_mode(
-            StartScanFallibleScanner::NewPayables,
+            UnableToStartScanner::NewPayables,
         );
     }
 
@@ -1054,7 +1054,7 @@ mod tests {
             let result = subject
                 .reschedule_on_error_resolver
                 .resolve_rescheduling_on_error(
-                    StartScanFallibleScanner::NewPayables,
+                    UnableToStartScanner::NewPayables,
                     *error,
                     false,
                     &logger,
@@ -1078,17 +1078,13 @@ mod tests {
         let test_name = "resolve_rescheduling_on_error_for_receivables_if_externally_triggered";
         let subject = ScanSchedulers::new(*TEST_SCAN_INTERVALS, true);
 
-        test_what_if_externally_triggered(
-            test_name,
-            &subject,
-            StartScanFallibleScanner::Receivables,
-        );
+        test_what_if_externally_triggered(test_name, &subject, UnableToStartScanner::Receivables);
     }
 
     #[test]
     fn resolve_error_for_receivables_if_null_scanner_is_used_in_automatic_mode() {
         test_resolve_error_if_null_scanner_is_used_in_automatic_mode(
-            StartScanFallibleScanner::Receivables,
+            UnableToStartScanner::Receivables,
         );
     }
 
@@ -1103,7 +1099,7 @@ mod tests {
                 subject
                     .reschedule_on_error_resolver
                     .resolve_rescheduling_on_error(
-                        StartScanFallibleScanner::Receivables,
+                        UnableToStartScanner::Receivables,
                         *error,
                         false,
                         &Logger::new("test"),
@@ -1128,34 +1124,32 @@ mod tests {
     #[test]
     fn conversion_between_hintable_scanner_and_scan_type_works() {
         assert_eq!(
-            ScanType::from(StartScanFallibleScanner::NewPayables),
+            ScanType::from(UnableToStartScanner::NewPayables),
             ScanType::Payables
         );
         assert_eq!(
-            ScanType::from(StartScanFallibleScanner::RetryPayables),
+            ScanType::from(UnableToStartScanner::RetryPayables),
             ScanType::Payables
         );
         assert_eq!(
-            ScanType::from(StartScanFallibleScanner::PendingPayables {
+            ScanType::from(UnableToStartScanner::PendingPayables {
                 initial_pending_payable_scan: false
             }),
             ScanType::PendingPayables
         );
         assert_eq!(
-            ScanType::from(StartScanFallibleScanner::PendingPayables {
+            ScanType::from(UnableToStartScanner::PendingPayables {
                 initial_pending_payable_scan: true
             }),
             ScanType::PendingPayables
         );
         assert_eq!(
-            ScanType::from(StartScanFallibleScanner::Receivables),
+            ScanType::from(UnableToStartScanner::Receivables),
             ScanType::Receivables
         )
     }
 
-    fn test_resolve_error_if_null_scanner_is_used_in_automatic_mode(
-        scanner: StartScanFallibleScanner,
-    ) {
+    fn test_resolve_error_if_null_scanner_is_used_in_automatic_mode(scanner: UnableToStartScanner) {
         let subject = ScanSchedulers::new(*TEST_SCAN_INTERVALS, true);
 
         let result = subject

--- a/node/src/accountant/scanners/test_utils.rs
+++ b/node/src/accountant/scanners/test_utils.rs
@@ -19,7 +19,7 @@ use crate::accountant::scanners::pending_payable_scanner::{
 };
 use crate::accountant::scanners::scan_schedulers::{
     NewPayableScanIntervalComputer, RescheduleScanOnErrorResolver, ScanReschedulingAfterEarlyStop,
-    ScanTiming, StartScanFallibleScanner,
+    ScanTiming, UnableToStartScanner,
 };
 use crate::accountant::scanners::{
     PendingPayableScanner, PrivateScanner, RealScannerMarker, ReceivableScanner, Scanner,
@@ -477,14 +477,14 @@ pub fn assert_timestamps_from_str(examined_str: &str, expected_timestamps: Vec<S
 #[derive(Default)]
 pub struct RescheduleScanOnErrorResolverMock {
     resolve_rescheduling_on_error_params:
-        Arc<Mutex<Vec<(StartScanFallibleScanner, StartScanError, bool, Logger)>>>,
+        Arc<Mutex<Vec<(UnableToStartScanner, StartScanError, bool, Logger)>>>,
     resolve_rescheduling_on_error_results: RefCell<Vec<ScanReschedulingAfterEarlyStop>>,
 }
 
 impl RescheduleScanOnErrorResolver for RescheduleScanOnErrorResolverMock {
     fn resolve_rescheduling_on_error(
         &self,
-        scanner: StartScanFallibleScanner,
+        scanner: UnableToStartScanner,
         error: &StartScanError,
         is_externally_triggered: bool,
         logger: &Logger,
@@ -507,7 +507,7 @@ impl RescheduleScanOnErrorResolver for RescheduleScanOnErrorResolverMock {
 impl RescheduleScanOnErrorResolverMock {
     pub fn resolve_rescheduling_on_error_params(
         mut self,
-        params: &Arc<Mutex<Vec<(StartScanFallibleScanner, StartScanError, bool, Logger)>>>,
+        params: &Arc<Mutex<Vec<(UnableToStartScanner, StartScanError, bool, Logger)>>>,
     ) -> Self {
         self.resolve_rescheduling_on_error_params = params.clone();
         self

--- a/node/src/blockchain/blockchain_agent/agent_web3.rs
+++ b/node/src/blockchain/blockchain_agent/agent_web3.rs
@@ -118,11 +118,13 @@ mod tests {
         BlockchainAgentWeb3, WEB3_MAXIMAL_GAS_LIMIT_MARGIN,
     };
     use crate::blockchain::blockchain_agent::BlockchainAgent;
-    use crate::blockchain::blockchain_bridge::increase_gas_price_by_margin;
+    use crate::blockchain::blockchain_bridge::increase_by_percentage;
     use crate::test_utils::make_wallet;
     use itertools::{Either, Itertools};
     use masq_lib::blockchains::chains::Chain;
-    use masq_lib::constants::DEFAULT_GAS_PRICE_MARGIN;
+    use masq_lib::constants::{
+        DEFAULT_GAS_PRICE_RETRY_CONSTANT, DEFAULT_GAS_PRICE_RETRY_PERCENTAGE,
+    };
     use masq_lib::logger::Logger;
     use masq_lib::test_utils::logging::{init_test_logging, TestLogHandler};
     use masq_lib::test_utils::utils::TEST_DEFAULT_CHAIN;
@@ -155,7 +157,7 @@ mod tests {
 
         let result = subject.price_qualified_payables(Either::Left(new_tx_templates.clone()));
 
-        let gas_price_with_margin_wei = increase_gas_price_by_margin(rpc_gas_price_wei);
+        let gas_price_with_margin_wei = increase_by_percentage(rpc_gas_price_wei);
         let expected_result = Either::Left(PricedNewTxTemplates::new(
             new_tx_templates,
             gas_price_with_margin_wei,
@@ -170,30 +172,32 @@ mod tests {
         let test_name = "returns_correct_priced_qualified_payables_for_retry_payable_scan";
         let consuming_wallet = make_wallet("efg");
         let consuming_wallet_balances = make_zeroed_consuming_wallet_balances();
-        let rpc_gas_price_wei = 444_555_666;
+        let latest_gas_price_wei = 444_555_666;
         let chain = TEST_DEFAULT_CHAIN;
+        let prev_gas_prices = vec![
+            latest_gas_price_wei - 1,
+            latest_gas_price_wei,
+            latest_gas_price_wei + 1,
+            latest_gas_price_wei - 123_456,
+            latest_gas_price_wei + 456_789,
+        ];
         let retry_tx_templates: Vec<RetryTxTemplate> = {
-            vec![
-                rpc_gas_price_wei - 1,
-                rpc_gas_price_wei,
-                rpc_gas_price_wei + 1,
-                rpc_gas_price_wei - 123_456,
-                rpc_gas_price_wei + 456_789,
-            ]
-            .into_iter()
-            .enumerate()
-            .map(|(idx, prev_gas_price_wei)| {
-                let account = make_payable_account((idx as u64 + 1) * 3_000);
-                RetryTxTemplate {
-                    base: BaseTxTemplate::from(&account),
-                    prev_gas_price_wei,
-                    prev_nonce: idx as u64,
-                }
-            })
-            .collect_vec()
+            prev_gas_prices
+                .iter()
+                .copied()
+                .enumerate()
+                .map(|(idx, prev_gas_price_wei)| {
+                    let account = make_payable_account((idx as u64 + 1) * 3_000);
+                    RetryTxTemplate {
+                        base: BaseTxTemplate::from(&account),
+                        prev_gas_price_wei,
+                        prev_nonce: idx as u64,
+                    }
+                })
+                .collect_vec()
         };
         let mut subject = BlockchainAgentWeb3::new(
-            rpc_gas_price_wei,
+            latest_gas_price_wei,
             77_777,
             consuming_wallet,
             consuming_wallet_balances,
@@ -205,23 +209,27 @@ mod tests {
             .price_qualified_payables(Either::Right(RetryTxTemplates(retry_tx_templates.clone())));
 
         let expected_result = {
-            let price_wei_for_accounts_from_1_to_5 = vec![
-                increase_gas_price_by_margin(rpc_gas_price_wei),
-                increase_gas_price_by_margin(rpc_gas_price_wei),
-                increase_gas_price_by_margin(rpc_gas_price_wei + 1),
-                increase_gas_price_by_margin(rpc_gas_price_wei),
-                increase_gas_price_by_margin(rpc_gas_price_wei + 456_789),
-            ];
-            if price_wei_for_accounts_from_1_to_5.len() != retry_tx_templates.len() {
+            let computed_gas_prices = prev_gas_prices
+                .into_iter()
+                .map(|prev_gas_price_wei| {
+                    PricedRetryTxTemplate::compute_gas_price(
+                        latest_gas_price_wei,
+                        prev_gas_price_wei,
+                    )
+                })
+                .collect::<Vec<u128>>();
+            if computed_gas_prices.len() != retry_tx_templates.len() {
                 panic!("Corrupted test")
             }
-
             Either::Right(PricedRetryTxTemplates(
                 retry_tx_templates
                     .iter()
-                    .zip(price_wei_for_accounts_from_1_to_5.into_iter())
-                    .map(|(retry_tx_template, increased_gas_price)| {
-                        PricedRetryTxTemplate::new(retry_tx_template.clone(), increased_gas_price)
+                    .zip(computed_gas_prices.into_iter())
+                    .map(|(retry_tx_template, computed_gas_price_wei)| {
+                        PricedRetryTxTemplate::new(
+                            retry_tx_template.clone(),
+                            computed_gas_price_wei,
+                        )
                     })
                     .collect_vec(),
             ))
@@ -238,9 +246,10 @@ mod tests {
         // This should be the value that would surplus the ceiling just slightly if the margin is
         // applied.
         // Adding just 1 didn't work, therefore 2
-        let rpc_gas_price_wei =
-            ((ceiling_gas_price_wei * 100) / (DEFAULT_GAS_PRICE_MARGIN as u128 + 100)) + 2;
-        let check_value_wei = increase_gas_price_by_margin(rpc_gas_price_wei);
+        let rpc_gas_price_wei = ((ceiling_gas_price_wei * 100)
+            / (DEFAULT_GAS_PRICE_RETRY_PERCENTAGE as u128 + 100))
+            + 2;
+        let check_value_wei = increase_by_percentage(rpc_gas_price_wei);
 
         test_gas_price_must_not_break_through_ceiling_value_in_the_new_payable_mode(
             test_name,
@@ -340,8 +349,8 @@ mod tests {
         // applied.
         // Adding just 1 didn't work, therefore 2
         let rpc_gas_price_wei =
-            (ceiling_gas_price_wei * 100) / (DEFAULT_GAS_PRICE_MARGIN as u128 + 100) + 2;
-        let check_value_wei = increase_gas_price_by_margin(rpc_gas_price_wei);
+            (ceiling_gas_price_wei * 100) / (DEFAULT_GAS_PRICE_RETRY_PERCENTAGE as u128 + 100) + 2;
+        let check_value_wei = increase_by_percentage(rpc_gas_price_wei);
         let template_1 = RetryTxTemplateBuilder::new()
             .payable_account(&account_1)
             .prev_gas_price_wei(rpc_gas_price_wei - 1)
@@ -382,18 +391,17 @@ mod tests {
         let account_1 = make_payable_account(12);
         let account_2 = make_payable_account(34);
         let ceiling_gas_price_wei = chain.rec().gas_price_safe_ceiling_minor;
-        // This should be the value that would surplus the ceiling just slightly if the margin is applied
-        let border_gas_price_wei =
-            (ceiling_gas_price_wei * 100) / (DEFAULT_GAS_PRICE_MARGIN as u128 + 100) + 2;
-        let rpc_gas_price_wei = border_gas_price_wei - 1;
-        let check_value_wei = increase_gas_price_by_margin(border_gas_price_wei);
+        // Once the gas price is computed from latest and prev gas price values, it'll break the ceiling
+        let prev_gas_price_wei = ceiling_gas_price_wei + 1 - DEFAULT_GAS_PRICE_RETRY_CONSTANT;
+        let latest_gas_price_wei = prev_gas_price_wei - 1;
+        let check_value_wei = prev_gas_price_wei + DEFAULT_GAS_PRICE_RETRY_CONSTANT;
         let template_1 = RetryTxTemplateBuilder::new()
             .payable_account(&account_1)
-            .prev_gas_price_wei(border_gas_price_wei)
+            .prev_gas_price_wei(prev_gas_price_wei)
             .build();
         let template_2 = RetryTxTemplateBuilder::new()
             .payable_account(&account_2)
-            .prev_gas_price_wei(border_gas_price_wei)
+            .prev_gas_price_wei(prev_gas_price_wei)
             .build();
         let retry_tx_templates = vec![template_1, template_2];
         let expected_log_msg = format!(
@@ -406,7 +414,7 @@ mod tests {
         test_gas_price_must_not_break_through_ceiling_value_in_the_retry_payable_mode(
             test_name,
             chain,
-            rpc_gas_price_wei,
+            latest_gas_price_wei,
             Either::Right(RetryTxTemplates(retry_tx_templates)),
             &expected_log_msg,
         );
@@ -466,8 +474,8 @@ mod tests {
         let expected_log_msg = format!(
             "The computed gas price(s) in wei is above the ceil value of 50,000,000,000 wei computed by this Node.\n\
              Transaction(s) to following receivers are affected:\n\
-             0x00000000000000000000000077616c6c65743132 with gas price 64,999,999,998\n\
-             0x00000000000000000000000077616c6c65743334 with gas price 64,999,999,997"
+             0x00000000000000000000000077616c6c65743132 with gas price 50,000,004,999\n\
+             0x00000000000000000000000077616c6c65743334 with gas price 50,000,004,998"
         );
 
         test_gas_price_must_not_break_through_ceiling_value_in_the_retry_payable_mode(
@@ -602,8 +610,7 @@ mod tests {
 
         assert_eq!(
             result,
-            (2 * (77_777 + WEB3_MAXIMAL_GAS_LIMIT_MARGIN))
-                * increase_gas_price_by_margin(444_555_666)
+            (2 * (77_777 + WEB3_MAXIMAL_GAS_LIMIT_MARGIN)) * increase_by_percentage(444_555_666)
         );
     }
 
@@ -611,30 +618,32 @@ mod tests {
     fn estimate_transaction_fee_total_works_for_retry_txs() {
         let consuming_wallet = make_wallet("efg");
         let consuming_wallet_balances = make_zeroed_consuming_wallet_balances();
-        let rpc_gas_price_wei = 444_555_666;
+        let latest_gas_price_wei = 444_555_666;
         let chain = TEST_DEFAULT_CHAIN;
+        let prev_gas_prices = vec![
+            latest_gas_price_wei - 1,
+            latest_gas_price_wei,
+            latest_gas_price_wei + 1,
+            latest_gas_price_wei - 123_456,
+            latest_gas_price_wei + 456_789,
+        ];
         let retry_tx_templates: Vec<RetryTxTemplate> = {
-            vec![
-                rpc_gas_price_wei - 1,
-                rpc_gas_price_wei,
-                rpc_gas_price_wei + 1,
-                rpc_gas_price_wei - 123_456,
-                rpc_gas_price_wei + 456_789,
-            ]
-            .into_iter()
-            .enumerate()
-            .map(|(idx, prev_gas_price_wei)| {
-                let account = make_payable_account((idx as u64 + 1) * 3_000);
-                RetryTxTemplate {
-                    base: BaseTxTemplate::from(&account),
-                    prev_gas_price_wei,
-                    prev_nonce: idx as u64,
-                }
-            })
-            .collect()
+            prev_gas_prices
+                .iter()
+                .copied()
+                .enumerate()
+                .map(|(idx, prev_gas_price_wei)| {
+                    let account = make_payable_account((idx as u64 + 1) * 3_000);
+                    RetryTxTemplate {
+                        base: BaseTxTemplate::from(&account),
+                        prev_gas_price_wei,
+                        prev_nonce: idx as u64,
+                    }
+                })
+                .collect()
         };
         let subject = BlockchainAgentWeb3::new(
-            rpc_gas_price_wei,
+            latest_gas_price_wei,
             77_777,
             consuming_wallet,
             consuming_wallet_balances,
@@ -645,15 +654,11 @@ mod tests {
 
         let result = subject.estimate_transaction_fee_total(&priced_qualified_payables);
 
-        let gas_prices_for_accounts_from_1_to_5 = vec![
-            increase_gas_price_by_margin(rpc_gas_price_wei),
-            increase_gas_price_by_margin(rpc_gas_price_wei),
-            increase_gas_price_by_margin(rpc_gas_price_wei + 1),
-            increase_gas_price_by_margin(rpc_gas_price_wei),
-            increase_gas_price_by_margin(rpc_gas_price_wei + 456_789),
-        ];
-        let expected_result = gas_prices_for_accounts_from_1_to_5
+        let expected_result = prev_gas_prices
             .into_iter()
+            .map(|prev_gas_price_wei| {
+                PricedRetryTxTemplate::compute_gas_price(latest_gas_price_wei, prev_gas_price_wei)
+            })
             .sum::<u128>()
             * (77_777 + WEB3_MAXIMAL_GAS_LIMIT_MARGIN);
         assert_eq!(result, expected_result)

--- a/node/src/blockchain/blockchain_bridge.rs
+++ b/node/src/blockchain/blockchain_bridge.rs
@@ -39,7 +39,7 @@ use actix::{Addr, Recipient};
 use futures::Future;
 use itertools::{Either, Itertools};
 use masq_lib::blockchains::chains::Chain;
-use masq_lib::constants::DEFAULT_GAS_PRICE_MARGIN;
+use masq_lib::constants::DEFAULT_GAS_PRICE_RETRY_PERCENTAGE;
 use masq_lib::logger::Logger;
 use masq_lib::ui_gateway::NodeFromUiMessage;
 use regex::Regex;
@@ -542,8 +542,8 @@ struct PendingTxInfo {
     when_sent: SystemTime,
 }
 
-pub fn increase_gas_price_by_margin(gas_price: u128) -> u128 {
-    (gas_price * (100 + DEFAULT_GAS_PRICE_MARGIN as u128)) / 100
+pub fn increase_by_percentage(gas_price: u128) -> u128 {
+    (gas_price * (100 + DEFAULT_GAS_PRICE_RETRY_PERCENTAGE as u128)) / 100
 }
 
 pub struct BlockchainBridgeSubsFactoryReal {}
@@ -775,7 +775,7 @@ mod tests {
         let accountant_received_payment = accountant_recording_arc.lock().unwrap();
         let blockchain_agent_with_context_msg_actual: &PricedTemplatesMessage =
             accountant_received_payment.get_record(0);
-        let computed_gas_price_wei = increase_gas_price_by_margin(0x230000000);
+        let computed_gas_price_wei = increase_by_percentage(0x230000000);
         let expected_tx_templates = tx_templates
             .iter()
             .map(|tx_template| PricedNewTxTemplate {
@@ -2239,7 +2239,7 @@ mod tests {
 
     #[test]
     fn increase_gas_price_by_margin_works() {
-        assert_eq!(increase_gas_price_by_margin(1_000_000_000), 1_300_000_000);
-        assert_eq!(increase_gas_price_by_margin(9_000_000_000), 11_700_000_000);
+        assert_eq!(increase_by_percentage(1_000_000_000), 1_300_000_000);
+        assert_eq!(increase_by_percentage(9_000_000_000), 11_700_000_000);
     }
 }

--- a/node/src/blockchain/blockchain_interface/blockchain_interface_web3/mod.rs
+++ b/node/src/blockchain/blockchain_interface/blockchain_interface_web3/mod.rs
@@ -473,7 +473,6 @@ mod tests {
     use super::*;
     use crate::accountant::scanners::pending_payable_scanner::utils::TxHashByTable;
     use crate::accountant::test_utils::make_payable_account;
-    use crate::blockchain::blockchain_bridge::increase_gas_price_by_margin;
     use crate::blockchain::blockchain_interface::blockchain_interface_web3::{
         BlockchainInterfaceWeb3, CONTRACT_ABI, REQUESTS_IN_PARALLEL, TRANSACTION_LITERAL,
         TRANSFER_METHOD_ID,
@@ -505,10 +504,12 @@ mod tests {
     use itertools::Either;
     use web3::transports::Http;
     use web3::types::{H256, U256};
+    use masq_lib::constants::DEFAULT_GAS_PRICE_RETRY_CONSTANT;
     use crate::accountant::scanners::payable_scanner::tx_templates::initial::new::NewTxTemplates;
     use crate::accountant::scanners::payable_scanner::tx_templates::initial::retry::RetryTxTemplates;
     use crate::accountant::scanners::payable_scanner::tx_templates::priced::retry::PricedRetryTxTemplate;
     use crate::accountant::scanners::payable_scanner::tx_templates::test_utils::RetryTxTemplateBuilder;
+    use crate::blockchain::blockchain_bridge::increase_by_percentage;
 
     #[test]
     fn constants_are_correct() {
@@ -888,7 +889,7 @@ mod tests {
         let gas_price_wei_from_rpc_u128_wei =
             u128::from_str_radix(&gas_price_wei_from_rpc_hex[2..], 16).unwrap();
         let gas_price_wei_from_rpc_u128_wei_with_margin =
-            increase_gas_price_by_margin(gas_price_wei_from_rpc_u128_wei);
+            increase_by_percentage(gas_price_wei_from_rpc_u128_wei);
         let expected_result = Either::Left(PricedNewTxTemplates::new(
             tx_templates.clone(),
             gas_price_wei_from_rpc_u128_wei_with_margin,
@@ -906,32 +907,32 @@ mod tests {
     #[test]
     fn blockchain_interface_web3_can_introduce_blockchain_agent_in_the_retry_payables_mode() {
         let gas_price_wei = "0x3B9ACA00"; // 1000000000
-        let gas_price_from_rpc = u128::from_str_radix(&gas_price_wei[2..], 16).unwrap();
+        let latest_gas_price_wei = u128::from_str_radix(&gas_price_wei[2..], 16).unwrap();
         let retry_1 = RetryTxTemplateBuilder::default()
             .payable_account(&make_payable_account(12))
-            .prev_gas_price_wei(gas_price_from_rpc - 1)
+            .prev_gas_price_wei(latest_gas_price_wei - 1)
             .build();
         let retry_2 = RetryTxTemplateBuilder::default()
             .payable_account(&make_payable_account(34))
-            .prev_gas_price_wei(gas_price_from_rpc)
+            .prev_gas_price_wei(latest_gas_price_wei)
             .build();
         let retry_3 = RetryTxTemplateBuilder::default()
             .payable_account(&make_payable_account(56))
-            .prev_gas_price_wei(gas_price_from_rpc + 1)
+            .prev_gas_price_wei(latest_gas_price_wei + 1)
             .build();
 
         let retry_tx_templates =
             RetryTxTemplates(vec![retry_1.clone(), retry_2.clone(), retry_3.clone()]);
         let expected_retry_tx_templates = PricedRetryTxTemplates(vec![
-            PricedRetryTxTemplate::new(retry_1, increase_gas_price_by_margin(gas_price_from_rpc)),
-            PricedRetryTxTemplate::new(retry_2, increase_gas_price_by_margin(gas_price_from_rpc)),
+            PricedRetryTxTemplate::new(retry_1, increase_by_percentage(latest_gas_price_wei)),
+            PricedRetryTxTemplate::new(retry_2, increase_by_percentage(latest_gas_price_wei)),
             PricedRetryTxTemplate::new(
                 retry_3,
-                increase_gas_price_by_margin(gas_price_from_rpc + 1),
+                (latest_gas_price_wei + 1) + DEFAULT_GAS_PRICE_RETRY_CONSTANT,
             ),
         ]);
 
-        let expected_estimated_transaction_fee_total = 285_979_200_073_328;
+        let expected_estimated_transaction_fee_total = 263_981_166_713_328;
 
         test_blockchain_interface_web3_can_introduce_blockchain_agent(
             Either::Right(retry_tx_templates),

--- a/node/src/blockchain/blockchain_interface_initializer.rs
+++ b/node/src/blockchain/blockchain_interface_initializer.rs
@@ -47,7 +47,7 @@ mod tests {
     use crate::accountant::scanners::payable_scanner::tx_templates::initial::new::NewTxTemplates;
     use crate::accountant::scanners::payable_scanner::tx_templates::priced::new::PricedNewTxTemplates;
     use crate::accountant::test_utils::make_payable_account;
-    use crate::blockchain::blockchain_bridge::increase_gas_price_by_margin;
+    use crate::blockchain::blockchain_bridge::increase_by_percentage;
     use crate::blockchain::blockchain_interface_initializer::BlockchainInterfaceInitializer;
     use crate::test_utils::make_wallet;
     use futures::Future;
@@ -88,7 +88,7 @@ mod tests {
             .unwrap();
         assert_eq!(blockchain_agent.consuming_wallet(), &payable_wallet);
         let result = blockchain_agent.price_qualified_payables(Either::Left(tx_templates.clone()));
-        let gas_price_with_margin = increase_gas_price_by_margin(1_000_000_000);
+        let gas_price_with_margin = increase_by_percentage(1_000_000_000);
         let expected_result = Either::Left(PricedNewTxTemplates::new(
             tx_templates,
             gas_price_with_margin,

--- a/node/src/test_utils/recorder.rs
+++ b/node/src/test_utils/recorder.rs
@@ -643,7 +643,7 @@ impl PeerActorsBuilder {
     // This must be called after System.new and before System.run.
     //
     // The addresses may be helpful for setting up the Counter Messages.
-    pub fn build_providing_addresses(self) -> (PeerActors, PeerActorAddrs) {
+    pub fn build_with_addresses(self) -> (PeerActors, PeerActorAddrs) {
         let proxy_server_addr = self.proxy_server.start();
         let dispatcher_addr = self.dispatcher.start();
         let hopper_addr = self.hopper.start();
@@ -684,7 +684,7 @@ impl PeerActorsBuilder {
 
     // This must be called after System.new and before System.run
     pub fn build(self) -> PeerActors {
-        let (peer_actors, _) = self.build_providing_addresses();
+        let (peer_actors, _) = self.build_with_addresses();
         peer_actors
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors scan error/types and rescheduling flow, replaces gas price margin with percentage + constant (incl. retry logic), and tweaks receivables scheduling; updates all call sites and tests.
> 
> - **Core error model and scheduling**:
>   - Replace `StartFallibleScanner` with `UnableToStartScanner`; rework `StartScanError` into concrete variants (`NothingToProcess`, `NoConsumingWalletFound`, `ScanAlreadyRunning`, `CalledFromNullScanner`, `ManualTriggerError`).
>   - `StartScanError::log_error` now requires `is_externally_triggered`; propagate flag through handlers and `RescheduleScanOnErrorResolver`.
>   - Update resolver signatures and logic to account for external triggers and new error variants; add `VariantCount` checks in tests.
>   - Remove helper `start_correct_payable_scanner`; call `StartableScanner` directly for payable modes.
> - **Blockchain gas price computation**:
>   - Rename `increase_gas_price_by_margin` → `increase_by_percentage` and change constant `DEFAULT_GAS_PRICE_MARGIN` → `DEFAULT_GAS_PRICE_RETRY_PERCENTAGE`; add `DEFAULT_GAS_PRICE_RETRY_CONSTANT`.
>   - New retry pricing: if latest ≥ previous use percentage; otherwise add constant. Apply in `PricedRetryTxTemplate::compute_gas_price` and across pricing/fee estimation paths.
>   - Enforce ceiling logging/messages updated; all usages and tests migrated.
> - **Accountant behavior**:
>   - In `Handler<ReceivedPayments>`, only reschedule receivables when no UI response; otherwise skip scheduling.
>   - Pending-payables manual denial hint text updated ("Run the Payable scanner first.").
> - **Tests**:
>   - Wide test updates for new enums, logging severities, retry gas pricing, ceilings, and fee totals.
>   - Introduce utilities for variant exhaustiveness and remove obsolete cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c5f218f7ddcbf3a07b2d3f0eedabdf4d082681a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->