### PR TITLE
v0.9.1: version bump

### DIFF
--- a/automap/Cargo.lock
+++ b/automap/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "automap"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "crossbeam-channel 0.5.8",
  "flexi_logger",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "ip_country"
-version = "0.1.0"
+version = "0.9.1"
 dependencies = [
  "csv",
  "ipnetwork",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "masq_lib"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "actix",
  "clap",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "test_utilities"
-version = "0.1.0"
+version = "0.9.1"
 
 [[package]]
 name = "textwrap"

--- a/automap/Cargo.toml
+++ b/automap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automap"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Dan Wiebe <dnwiebe@gmail.com>", "MASQ"]
 license = "GPL-3.0-only"
 description = "Library full of code to make routers map ports through firewalls"

--- a/dns_utility/Cargo.lock
+++ b/dns_utility/Cargo.lock
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "dns_utility"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "core-foundation",
  "ipconfig 0.2.2",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "ip_country"
-version = "0.1.0"
+version = "0.9.1"
 dependencies = [
  "csv",
  "ipnetwork",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "masq_lib"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "actix",
  "clap",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "test_utilities"
-version = "0.1.0"
+version = "0.9.1"
 
 [[package]]
 name = "textwrap"

--- a/dns_utility/Cargo.toml
+++ b/dns_utility/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns_utility"
-version = "0.9.0"
+version = "0.9.1"
 license = "GPL-3.0-only"
 authors = ["Dan Wiebe <dnwiebe@gmail.com>", "MASQ"]
 copyright = "Copyright (c) 2019, MASQ (https://masq.ai) and/or its affiliates. All rights reserved."

--- a/ip_country/Cargo.toml
+++ b/ip_country/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ip_country"
-version = "0.1.0"
+version = "0.9.1"
 edition = "2021"
 license = "GPL-3.0-only"
 authors = ["Dan Wiebe <dnwiebe@gmail.com>", "MASQ"]

--- a/masq/Cargo.toml
+++ b/masq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masq"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Dan Wiebe <dnwiebe@gmail.com>", "MASQ"]
 license = "GPL-3.0-only"
 description = "Reference implementation of user interface for MASQ Node"

--- a/masq_lib/Cargo.toml
+++ b/masq_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masq_lib"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Dan Wiebe <dnwiebe@gmail.com>", "MASQ"]
 license = "GPL-3.0-only"
 description = "Code common to Node and masq; also, temporarily, to dns_utility"

--- a/multinode_integration_tests/Cargo.toml
+++ b/multinode_integration_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multinode_integration_tests"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Dan Wiebe <dnwiebe@gmail.com>", "MASQ"]
 license = "GPL-3.0-only"
 description = ""

--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -182,7 +182,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "automap"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "crossbeam-channel 0.5.1",
  "flexi_logger 0.17.1",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "ip_country"
-version = "0.1.0"
+version = "0.9.1"
 dependencies = [
  "csv",
  "ipnetwork",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "masq"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "atty",
  "clap",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "masq_lib"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "actix",
  "clap",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "multinode_integration_tests"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64 0.13.0",
  "crossbeam-channel 0.5.1",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "node"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "actix",
  "automap",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "test_utilities"
-version = "0.1.0"
+version = "0.9.1"
 
 [[package]]
 name = "textwrap"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node"
-version = "0.9.0"
+version = "0.9.1"
 license = "GPL-3.0-only"
 authors = ["Dan Wiebe <dnwiebe@gmail.com>", "MASQ"]
 description = "MASQ Node is the foundation of MASQ Network, an open-source network that allows anyone to allocate spare computing resources to make the internet a free and fair place for the entire world."

--- a/port_exposer/Cargo.lock
+++ b/port_exposer/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "port_exposer"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "default-net",
 ]

--- a/port_exposer/Cargo.toml
+++ b/port_exposer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "port_exposer"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Dan Wiebe <dnwiebe@gmail.com>", "MASQ"]
 license = "GPL-3.0-only"
 copyright = "Copyright (c) 2019, MASQ (https://masq.ai) and/or its affiliates. All rights reserved."

--- a/test_utilities/Cargo.toml
+++ b/test_utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_utilities"
-version = "0.1.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Dan Wiebe <dnwiebe@gmail.com>", "MASQ"]
 license = "GPL-3.0-only"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Manifest/lockfile-only version bumps with no runtime or logic changes; risk is limited to packaging/release consistency issues.
> 
> **Overview**
> Bumps the release version across the Rust workspace from `0.9.0` to `0.9.1` (including `node`, `masq`, `masq_lib`, `automap`, `dns_utility`, `port_exposer`, `multinode_integration_tests`, `ip_country`, and `test_utilities`).
> 
> Updates the corresponding `Cargo.lock` entries so internal crates (`ip_country`, `test_utilities`) and workspace dependencies resolve to `0.9.1` consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ecca85cdc34fcc07a6642f65f24c7c60b810d83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->